### PR TITLE
Add source/target options to DNS filter

### DIFF
--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -77,7 +77,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
       raw = event[@source]
       if raw.is_a?(Array)
         if raw.length > 1
-          @logger.warn("DNS: skipping resolve, can't deal with multiple values", :field => field, :value => raw)
+          @logger.warn("DNS: skipping resolve, can't deal with multiple values", :field => @source, :value => raw)
           return
         end
         raw = raw.first
@@ -97,20 +97,20 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         end
       rescue Resolv::ResolvError
         @logger.debug("DNS: couldn't resolve.",
-                      :field => field, :value => raw)
+                      :field => @source, :value => raw)
         return
       rescue Resolv::ResolvTimeout
         @logger.debug("DNS: timeout on resolving.",
-                      :field => field, :value => raw)
+                      :field => @source, :value => raw)
         return
       rescue SocketError => e
         @logger.debug("DNS: Encountered SocketError.",
-                      :field => field, :value => raw)
+                      :field => @source, :value => raw)
         return
       rescue NoMethodError => e
         # see JRUBY-5647
         @logger.debug("DNS: couldn't resolve the hostname.",
-                      :field => field, :value => raw,
+                      :field => @source, :value => raw,
                       :extra => "NameError instead of ResolvError")
         return
       end

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -115,6 +115,9 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         return
       end
 
+      # Explicit encode, as Resolv returns ASCII
+      result.encode!('UTF-8')
+
       if @target.empty?
         event["dns"] = result
       else

--- a/spec/filters/dns.rb
+++ b/spec/filters/dns.rb
@@ -158,4 +158,67 @@ describe LogStash::Filters::DNS do
       insist { subject["foo"] } == "does.not.exist"
     end
   end
+
+  # Tests for the source/target options
+  describe "dns reverse lookup, no target" do
+    config <<-CONFIG
+      filter {
+        dns {
+          source => "host"
+        }
+      }
+    CONFIG
+
+    sample("host" => "199.192.228.250") do
+      insist { subject["host"] } == "199.192.228.250"
+      insist { subject["dns"] } == "carrera.databits.net"
+    end
+  end
+
+  describe "dns lookup, with target" do
+    config <<-CONFIG
+      filter {
+        dns {
+          source => "foo"
+          target => "bar"
+        }
+      }
+    CONFIG
+
+    sample("foo" => "199.192.228.250") do
+      insist { subject["foo"] } == "199.192.228.250"
+      insist { subject["bar"] } == "carrera.databits.net"
+    end
+  end
+
+  describe "dns lookup, NXDOMAIN, no target" do
+    config <<-CONFIG
+      filter {
+        dns {
+          source => "foo"
+        }
+      }
+    CONFIG
+
+    sample("foo" => "doesnotexist.invalid.topleveldomain") do
+      insist { subject["foo"] } == "doesnotexist.invalid.topleveldomain"
+      insist { subject["dns"] } == nil
+    end
+  end
+
+  describe "dns lookup, NXDOMAIN, with target" do
+    config <<-CONFIG
+      filter {
+        dns {
+          source => "foo"
+          target => "bar"
+        }
+      }
+    CONFIG
+
+    sample("foo" => "doesnotexist.invalid.topleveldomain") do
+      insist { subject["foo"] } == "doesnotexist.invalid.topleveldomain"
+      insist { subject["bar"] } == nil
+    end
+  end
 end


### PR DESCRIPTION
  * Solves LOGSTASH-1489
    * Doesn't close it, as the options have to be removed in a later version. This will be another pull request
  * Deprecate resolve, reverse and action options

I've tested and verified both the old and new functionality. Comments for the options have been changed to reflect the changes in configuration