### PR TITLE
Split filter: ability to split arrays within a JSON structure

### DIFF
--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -1,6 +1,6 @@
+# encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
-require "logstash/event"
 
 # JSON filter. Takes a field that contains JSON and expands it into
 # an actual datastructure.
@@ -41,9 +41,6 @@ class LogStash::Filters::Json < LogStash::Filters::Base
   # Note: if the "target" field already exists, it will be overwritten.
   config :target, :validate => :string
 
-  # Define a key containing an array of events to be split up and fed into LogStash as separate individual events.
-  config :array_split, :validate => :string
-
   public
   def register
     # Nothing to do here
@@ -65,34 +62,20 @@ class LogStash::Filters::Json < LogStash::Filters::Base
     end
 
     begin
-      source = JSON.parse(event[@source])
+      # TODO(sissel): Note, this will not successfully handle json lists
+      # like your text is '[ 1,2,3 ]' JSON.parse gives you an array (correctly)
+      # which won't merge into a hash. If someone needs this, we can fix it
+      # later.
+      dest.merge!(JSON.parse(event[@source]))
 
-      if !!@array_split
-
-        source[@array_split].each do |item|
-          next if item.empty?
-
-          event_split = LogStash::Event.new(item.clone)
-          @logger.debug("JSON Array Split item", :value => event_split)
-          filter_matched(event_split)
-
-          yield event_split # yield each item to be handled individually
-        end
-        event.cancel
-
-      else
-        dest.merge!(JSON.parse(event[@source]))
-
-        # This is a hack to help folks who are mucking with @timestamp during
-        # their json filter. You aren't supposed to do anything with "@timestamp"
-        # outside of the date filter, but nobody listens... ;)
-        if event["@timestamp"].is_a?(String)
-          event["@timestamp"] = Time.parse(event["@timestamp"]).gmtime
-        end
-
-        filter_matched(event)
+      # This is a hack to help folks who are mucking with @timestamp during
+      # their json filter. You aren't supposed to do anything with "@timestamp"
+      # outside of the date filter, but nobody listens... ;)
+      if event["@timestamp"].is_a?(String)
+        event["@timestamp"] = Time.parse(event["@timestamp"]).gmtime
       end
 
+      filter_matched(event)
     rescue => e
       event.tag("_jsonparsefailure")
       @logger.warn("Trouble parsing json", :source => @source,

--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require "logstash/event"
 
 # JSON filter. Takes a field that contains JSON and expands it into
 # an actual datastructure.
@@ -41,6 +41,9 @@ class LogStash::Filters::Json < LogStash::Filters::Base
   # Note: if the "target" field already exists, it will be overwritten.
   config :target, :validate => :string
 
+  # Define a key containing an array of events to be split up and fed into LogStash as separate individual events.
+  config :array_split, :validate => :string
+
   public
   def register
     # Nothing to do here
@@ -62,20 +65,34 @@ class LogStash::Filters::Json < LogStash::Filters::Base
     end
 
     begin
-      # TODO(sissel): Note, this will not successfully handle json lists
-      # like your text is '[ 1,2,3 ]' JSON.parse gives you an array (correctly)
-      # which won't merge into a hash. If someone needs this, we can fix it
-      # later.
-      dest.merge!(JSON.parse(event[@source]))
+      source = JSON.parse(event[@source])
 
-      # This is a hack to help folks who are mucking with @timestamp during
-      # their json filter. You aren't supposed to do anything with "@timestamp"
-      # outside of the date filter, but nobody listens... ;)
-      if event["@timestamp"].is_a?(String)
-        event["@timestamp"] = Time.parse(event["@timestamp"]).gmtime
+      if !!@array_split
+
+        source[@array_split].each do |item|
+          next if item.empty?
+
+          event_split = LogStash::Event.new(item.clone)
+          @logger.debug("JSON Array Split item", :value => event_split)
+          filter_matched(event_split)
+
+          yield event_split # yield each item to be handled individually
+        end
+        event.cancel
+
+      else
+        dest.merge!(JSON.parse(event[@source]))
+
+        # This is a hack to help folks who are mucking with @timestamp during
+        # their json filter. You aren't supposed to do anything with "@timestamp"
+        # outside of the date filter, but nobody listens... ;)
+        if event["@timestamp"].is_a?(String)
+          event["@timestamp"] = Time.parse(event["@timestamp"]).gmtime
+        end
+
+        filter_matched(event)
       end
 
-      filter_matched(event)
     rescue => e
       event.tag("_jsonparsefailure")
       @logger.warn("Trouble parsing json", :source => @source,

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require "logstash/event"
 
 # The split filter is for splitting multiline messages into separate events.
 #
@@ -22,6 +22,10 @@ class LogStash::Filters::Split < LogStash::Filters::Base
   # The field which value is split by the terminator
   config :field, :validate => :string, :default => "message"
 
+  # If true, the array data will be passed forward as a single hash element with @field as the key.
+  # If false, treat the entire array element as a new event for further processing.
+  config :reuse_element, :validate => :boolean, :default => true
+
   public
   def register
     # Nothing to do
@@ -31,27 +35,32 @@ class LogStash::Filters::Split < LogStash::Filters::Base
   def filter(event)
     return unless filter?(event)
 
-    events = []
+    splits = []
 
     original_value = event[@field]
 
-    # If for some reason the field is an array of values, take the first only.
-    original_value = original_value.first if original_value.is_a?(Array)
+    if original_value.is_a?(Array)
+      splits = original_value
+    else
+      # Using -1 for 'limit' on String#split makes ruby not drop trailing empty
+      # splits.
+      splits = original_value.split(@terminator, -1)
+    end
 
-    # Using -1 for 'limit' on String#split makes ruby not drop trailing empty
-    # splits.
-    splits = original_value.split(@terminator, -1)
-
-    # Skip filtering if splitting this event resulted in only one thing found.
-    return if splits.length == 1
-    #or splits[1].empty?
+    # Skip filtering if splitting this event resulted in only one thing found
+    return event if splits.length <= 1
 
     splits.each do |value|
       next if value.empty?
 
-      event_split = event.clone
-      @logger.debug("Split event", :value => value, :field => @field)
-      event_split[@field] = value
+      event_split = nil
+      if @reuse_element
+        event_split = event.clone
+        @logger.debug("Split event", :value => value, :field => @field)
+        event_split[@field] = value
+      else
+        event_split = LogStash::Event.new(value)
+      end
       filter_matched(event_split)
 
       # Push this new event onto the stack at the LogStash::FilterWorker

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -48,7 +48,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     end
 
     # Skip filtering if splitting this event resulted in only one thing found
-    return event if splits.length <= 1
+    return if splits.length <= 1
 
     splits.each do |value|
       next if value.empty?

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -53,7 +53,6 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     splits.each do |value|
       next if value.empty?
 
-      event_split = nil
       if @reuse_element
         event_split = event.clone
         @logger.debug("Split event", :value => value, :field => @field)


### PR DESCRIPTION
An update to the split filter which allows the user to divide an array within the JSON hash. The contents are split into multiple entries and yielded back for further processing. (Note: LogStash is not successfully refiltering new items yet, so they cannot be filtered a second time, but the results of the split do get pushed into the output stack.)

This is useful when the log data contains multiple event entries as an array.

The "reuse_element" config option determines whether the data is kept within the hash under its original key name (e.g. "Records"), or is converted into a base JSON structure. If "reuse_element" true, the array element within the hash is overwritten with the value of one of its elements. E.g. "Records" => [1,2,3,4] will lead to 4 different events, each one with "Records" => 1 (etc.)... If false, each individual array element would be returned into the results as a single hash with no key (this was my purpose in making the change, as my events are all together in one big array within the JSON).

Sample config section-- in this scenario, log data was returned as a single row of JSON data under the hash key "message". "Message" contained only the "Records" field, pointing to more JSON presented as an array of hashes. This configuration will allow the user to separate those records back into individual events. Since LogStash does not currently correctly re-filter "created events" (new events spawned by a filter, e.g. split) the below configuration's "date" filter section is never reached. I will be addressing this in a separate Pull Request.
  
filter {
  if !("splitted" in [tags])
  {
      json {
        source => "message"
      }
      split {
        field => "Records"
        reuse_element => false
        add_tag => ["splitted"]
      }
  }
  if ("splitted" in [tags])
  {
      date {
        add_tag => ["dated"]
        match => ["eventTime", "ISO8601"]
      }
  }
}