### PR TITLE
Fix coalesc fallback detection

### DIFF
--- a/lib/logstash/filters/alter.rb
+++ b/lib/logstash/filters/alter.rb
@@ -163,7 +163,7 @@ class LogStash::Filters::Alter < LogStash::Filters::Base
       subst_array = config[:subst_array]
       
       substitution_parsed = subst_array.map { |x| event.sprintf(x) }
-      not_nul_index = substitution_parsed.find_index { |x| not x.nil? and not x.eql?("nil") and not (not x.index("%").nil? && x.match(/%\{[^}]\}/).nil?) }
+      not_nul_index = substitution_parsed.find_index { |x| not x.nil? and not x.eql?("nil") and x.match(/%\{[^}]+\}/).nil? }
       if not not_nul_index.nil?
         event[field] = substitution_parsed[not_nul_index]
       end


### PR DESCRIPTION
Bugs fixed:
* If sprintf(x) populates the field with a value containing a '%' character, the 'x.index("%").nil?' check of find_index assumes that it has an unpopulated "%{asdf}" sprintf resulted and skips the value.
Example:
If the "field" value was "100%", then 'coalesce => [ "field", "%{field}", "default" ]' would result in the value of "field" being "default", rather than "100%".
**Edit: this was actually a result of incorrect boolean logic. The original line should have been "and not x.match().nil?".**

* The "/%\{[^}]\}/" regex is incorrect, it should be "/%\{[^}]+\}/" (note the "[^}]+"). It would match "%{a}", but not "%{aa}". Could optionally be "[^}]*", but I do not know if "%{}" is an acceptable value.