### PR TITLE
adding tag "_jsonparsefailure" for failures in json-codecs

### DIFF
--- a/lib/logstash/codecs/json.rb
+++ b/lib/logstash/codecs/json.rb
@@ -36,7 +36,7 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
       yield LogStash::Event.new(JSON.parse(data))
     rescue JSON::ParserError => e
       @logger.info("JSON parse failure. Falling back to plain-text", :error => e, :data => data)
-      yield LogStash::Event.new("message" => data)
+      yield LogStash::Event.new({ "message" => data, "tags" => "_jsonparsefailure" })
     end
   end # def decode
 

--- a/lib/logstash/codecs/json_lines.rb
+++ b/lib/logstash/codecs/json_lines.rb
@@ -37,7 +37,7 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
         yield LogStash::Event.new(JSON.parse(event["message"]))
       rescue JSON::ParserError => e
         @logger.info("JSON parse failure. Falling back to plain-text", :error => e, :data => data)
-        yield LogStash::Event.new("message" => event["message"])
+        yield LogStash::Event.new({ "message" => event["message"], "tags" => "_jsonparsefailure" })
       end
     end
   end # def decode

--- a/spec/codecs/json.rb
+++ b/spec/codecs/json.rb
@@ -44,6 +44,7 @@ describe LogStash::Codecs::JSON do
           decoded = true
           insist { event.is_a?(LogStash::Event) }
           insist { event["message"] } == "something that isn't json"
+          insist { event["tags"] }.include?("_jsonparsefailure")
         end
         insist { decoded } == true
       end


### PR DESCRIPTION
I've added the tag "_jsonparsefailure" in the codecs "json" and "json_lines" in case of parsing errors. So it's possible to filter out failed parsed json events and fix possible bugs in the input data.

Unfortunately I'm no ruby guru and i had problems to run the tests, but I've tested my changes by adding the files into the latest version (1.3.3) and it worked fine.
