### PR TITLE
Fix thread/connection leak in RabbitMQ::MarchHare

### DIFF
--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -53,6 +53,8 @@ class LogStash::Inputs::RabbitMQ
           n = 10
           @logger.error("RabbitMQ connection error: #{e}. Will reconnect in #{n} seconds...")
 
+          @conn.close if @conn && @conn.open?
+
           sleep n
           retry
         rescue LogStash::ShutdownSignal => ss

--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -103,6 +103,9 @@ class LogStash::Inputs::RabbitMQ
 
       # exchange binding is optional for the input
       if @exchange
+        @ch.exchange(@exchange,
+          :durable     => @durable,
+          :auto_delete => @auto_delete)
         @q.bind(@exchange, :routing_key => @key)
       end
     end

--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -70,8 +70,8 @@ class LogStash::Inputs::RabbitMQ
       shutdown_consumer
       @q.delete unless @durable
 
-      @ch.close         if @ch && @ch.open?
-      @connection.close if @connection && @connection.open?
+      @ch.close   if @ch && @ch.open?
+      @conn.close if @conn && @conn.open?
 
       finished
     end


### PR DESCRIPTION
On a non-connection-fatal exception (for example, if the queue was not found),
the error handling code would attempt to reconnect without closing the old
connection first. This resulted in hundreds of simultanious open connections,
tying up rabbitmq resources and causing local load problems as well,
with thousands of idle threads.