### PR TITLE
Add redis output congestion_attempts

### DIFF
--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -100,7 +100,7 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
   # its threshold. Will try connecting to the next server in the host
   # list after attempts is reached. This will take
   # time_in_secs = :congestion_interval * :congestion_attempts
-  config :congestion_attempts, :validate => :number, :default => 10
+  config :congestion_attempts, :validate => :number, :default => 0
 
   def register
     require 'redis'
@@ -195,7 +195,7 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
         @logger.warn? and @logger.warn("Redis key size has hit a congestion threshold #{@congestion_threshold} suspending output for #{@congestion_interval} seconds")
         sleep @congestion_interval
         tries += 1
-        if tries > @congestion_attempts
+        if tries > @congestion_attempts and @congestion_attempts > 0
             @redis = connect
             tries = 0
         end

--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -96,6 +96,12 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
   # Zero means to check on every event.
   config :congestion_interval, :validate => :number, :default => 1
 
+  # How many attempts to make to send to redis while congestion is at
+  # its threshold. Will try connecting to the next server in the host
+  # list after attempts is reached. This will take
+  # time_in_secs = :congestion_interval * :congestion_attempts
+  config :congestion_attempts, :validate => :number, :default => 10
+
   def register
     require 'redis'
 
@@ -183,10 +189,16 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
 
   def congestion_check(key)
     return if @congestion_threshold == 0
+    tries = 0
     if (Time.now.to_i - @congestion_check_times[key]) >= @congestion_interval # Check congestion only if enough time has passed since last check.
       while @redis.llen(key) > @congestion_threshold # Don't push event to Redis key which has reached @congestion_threshold.
         @logger.warn? and @logger.warn("Redis key size has hit a congestion threshold #{@congestion_threshold} suspending output for #{@congestion_interval} seconds")
         sleep @congestion_interval
+        tries += 1
+        if tries > @congestion_attempts
+            @redis = connect
+            tries = 0
+        end
       end
       @congestion_check_time = Time.now.to_i
     end


### PR DESCRIPTION
When a list of redis hosts is given to the redis output and the congestion_threshold is hit, it should try sending the output to a different host in the list after a certain number of attempts. This is useful in cases where the consumers of the redis lists are down. As it is now, logstash will just keep attempting to send output to the same host, rather than attempting another one in its list. 