### PR TITLE
Prevent broken docs, by adding a dot

### DIFF
--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -18,7 +18,7 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
   milestone 2
 
   # TODO(sissel): This should switch to use the 'line' codec by default
-  # once file following
+  # once file following.
   default :codec, "plain"
 
   # The path(s) to the file(s) to use as an input.


### PR DESCRIPTION
The incomplete sentence without dot breaks the online documentation.