### PR TITLE
Hint about http_proxy if download fails.

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -49,6 +49,7 @@ case $1 in
   	$DOWNLOAD_COMMAND ${TARGET} ${URLSTUB}${FILENAME}
   	if [ ! -f "${TARGET}" ]; then
 	  	echo "ERROR: Unable to download ${URLSTUB}${FILENAME}"
+	  	echo "HINT: If you're behind a proxy, specify the http_proxy variable."
 	  	echo "Exiting."
 	  	exit 1
 	fi


### PR DESCRIPTION
Running `bin/plugin install contrib` isn't obviously an action which will cause files to be downloaded with curl/wget.

A quick hint that a http_proxy variable should be set if the download fails might be quite useful and save people's time!