### PR TITLE
Adding a locale parameter to syslog input

### DIFF
--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -43,6 +43,9 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
   # Labels for severity levels. These are defined in RFC3164.
   config :severity_labels, :validate => :array, :default => [ "Emergency" , "Alert", "Critical", "Error", "Warning", "Notice", "Informational", "Debug" ]
 
+  # Locale
+  config :locale, :validate => :string
+
   public
   def initialize(params)
     super
@@ -58,8 +61,10 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
       "match" => { "message" => "<%{POSINT:priority}>%{SYSLOGLINE}" },
     )
 
+    locale = @config["locale"][0] if @config["locale"] != nil and @config["locale"][0] != nil
     @date_filter = LogStash::Filters::Date.new(
-      "match" => [ "timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss", "ISO8601"]
+      "match" => [ "timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss", "ISO8601"],
+      "locale" => locale
     )
 
     @grok_filter.register

--- a/spec/inputs/syslog.rb
+++ b/spec/inputs/syslog.rb
@@ -14,6 +14,7 @@ describe "inputs/syslog", :socket => true do
         syslog {
           type => "blah"
           port => #{port}
+          locale => "en"
         }
       }
     CONFIG
@@ -33,8 +34,8 @@ describe "inputs/syslog", :socket => true do
         insist { events[i]["priority"] } == 164
         insist { events[i]["severity"] } == 4
         insist { events[i]["facility"] } == 20
+        insist { events[i]["@timestamp"] } == "2014-10-26T14:19:25.000Z"
       end
     end
   end
 end
-


### PR DESCRIPTION
so it can be propagated to the date filter used in the syslog input.
That will allow users of the syslog input to specify the locale that should be used to parse the date, when the locales of the origin and destination are not the same.

Related Jira issue: https://logstash.jira.com/browse/LOGSTASH-1998