### PR TITLE
Fixes path to nologin in ubuntu

### DIFF
--- a/pkg/ubuntu/before-install.sh
+++ b/pkg/ubuntu/before-install.sh
@@ -8,5 +8,5 @@ fi
 # create logstash user
 if ! getent passwd logstash >/dev/null; then
   useradd -M -r -g logstash -d /var/lib/logstash \
-    -s /sbin/nologin -c "LogStash Service User" logstash
+    -s /usr/sbin/nologin -c "LogStash Service User" logstash
 fi


### PR DESCRIPTION
At least in 12.04 it's `/usr/sbin/nologin`