### PR TITLE
Make graphite plugin resilient to IOError

### DIFF
--- a/lib/logstash/outputs/graphite.rb
+++ b/lib/logstash/outputs/graphite.rb
@@ -133,7 +133,7 @@ class LogStash::Outputs::Graphite < LogStash::Outputs::Base
       # TODO(sissel): Test error cases. Catch exceptions. Find fortune and glory.
       begin
         @socket.puts(message)
-      rescue Errno::EPIPE, Errno::ECONNRESET => e
+      rescue Errno::EPIPE, Errno::ECONNRESET, IOError => e
         @logger.warn("Connection to graphite server died",
                      :exception => e, :host => @host, :port => @port)
         sleep(@reconnect_interval)


### PR DESCRIPTION
Add IOError to the list of problems caught when attempting to write to
Graphite.  Reason was because "IOError: Connection timed out" would percolate
out to the top level and exit logstash.