### PR TITLE
Update footer links for docs

### DIFF
--- a/docs/plugin-doc.html.erb
+++ b/docs/plugin-doc.html.erb
@@ -81,4 +81,8 @@ input {
 
 <hr>
 
-This is documentation from <a href="https://github.com/logstash/logstash/blob/v<%= LOGSTASH_VERSION %>/<%= file %>"><%= file %></a>
+<% if is_contrib_plugin -%>
+This is documentation from <a href="https://github.com/elasticsearch/logstash-contrib/blob/v<%= LOGSTASH_VERSION %>/<%= file %>"><%= file %></a>
+<% else -%>
+This is documentation from <a href="https://github.com/elasticsearch/logstash/blob/v<%= LOGSTASH_VERSION %>/<%= file %>"><%= file %></a>
+<% end -%>


### PR DESCRIPTION
Fix for LOGSTASH-2157

Update the footer to link to the correct repo (logstash vs elasticsearch) and point contrib plugins to the correct contrib repo. 

** This SHOULD work, however, I couldn't get "make docs" to run to verify. 