### PR TITLE
Add patterns for AWS S3 & ELB access log

### DIFF
--- a/patterns/aws
+++ b/patterns/aws
@@ -1,0 +1,11 @@
+S3_REQUEST_LINE (?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
+
+S3_ACCESS_LOG %{WORD:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} (?:"%{S3_REQUEST_LINE}"|-) (?:%{INT:response:int}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) (?:%{INT:request_time_ms:int}|-) (?:%{INT:turnaround_time_ms:int}|-) (?:%{QS:referrer}|-) (?:"?%{QS:agent}"?|-) (?:-|%{NOTSPACE:version_id})
+
+ELB_URIPATHPARAM %{URIPATH:path}(?:%{URIPARAM:params})?
+
+ELB_URI %{URIPROTO:proto}://(?:%{USER}(?::[^@]*)?@)?(?:%{URIHOST:urihost})?(?:%{ELB_URIPATHPARAM})?
+
+ELB_REQUEST_LINE (?:%{WORD:verb} %{ELB_URI:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
+
+ELB_ACCESS_LOG %{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:elb} %{IP:clientip}:%{INT:clientport:int} %{IP:backendip}:%{INT:backendport:int} %{NUMBER:request_processing_time:float} %{NUMBER:backend_processing_time:float} %{NUMBER:response_processing_time:float} %{INT:response:int} %{INT:backend_response:int} %{INT:received_bytes:int} %{INT:bytes:int} "%{ELB_REQUEST_LINE}"

--- a/patterns/s3
+++ b/patterns/s3
@@ -1,7 +1,4 @@
 S3_OP_TYPE SOAP|REST|WEBSITE
-
 S3_OPERATION %{S3_OP_TYPE:operation_type}\.%{WORD:operation}(\.%{WORD:resource_type})?
-
-S3_REQUEST_LINE (?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
-
-S3_ACCESS %{NOTSPACE:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{S3_OPERATION} %{NOTSPACE:key} "%{REQUEST_LINE}" %{INT:response:int} (?:%{NOTSPACE:error_code}|-) (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) %{INT:request_time_ms:int} (:?%{INT:turnaround_time_ms:int}|-) %{QS:referrer} %{QS:agent} (:?%{NOTSPACE:version_id}|-)
+S3_REQUEST_LINE (?:%{NOTSPACE:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
+S3_ACCESS %{NOTSPACE:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{S3_OPERATION} %{NOTSPACE:key} (?:"%{S3_REQUEST_LINE}"|-) %{INT:response:int} (?:%{NOTSPACE:error_code}|-) (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) (?:%{INT:request_time_ms:int}|-) (?:%{INT:turnaround_time_ms:int}|-) (?:%{QS:referrer}|-) (?:%{QS:agent}|-) (?:%{NOTSPACE:version_id}|-)

--- a/patterns/s3
+++ b/patterns/s3
@@ -1,4 +1,0 @@
-S3_OP_TYPE SOAP|REST|WEBSITE|BATCH
-S3_OPERATION %{S3_OP_TYPE:operation_type}\.%{WORD:operation}(\.%{WORD:resource_type})?
-S3_REQUEST_LINE (?:%{NOTSPACE:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
-S3_ACCESS %{NOTSPACE:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{S3_OPERATION} %{NOTSPACE:key} (?:"%{S3_REQUEST_LINE}"|-) %{INT:response:int} %{NOTSPACE:error_code} (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) (?:%{INT:request_time_ms:int}|-) (?:%{INT:turnaround_time_ms:int}|-) %{QS:referrer} "?%{QS:agent}"? %{NOTSPACE:version_id}

--- a/patterns/s3
+++ b/patterns/s3
@@ -1,4 +1,4 @@
-S3_OP_TYPE SOAP|REST|WEBSITE
+S3_OP_TYPE SOAP|REST|WEBSITE|BATCH
 S3_OPERATION %{S3_OP_TYPE:operation_type}\.%{WORD:operation}(\.%{WORD:resource_type})?
 S3_REQUEST_LINE (?:%{NOTSPACE:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
-S3_ACCESS %{NOTSPACE:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{S3_OPERATION} %{NOTSPACE:key} (?:"%{S3_REQUEST_LINE}"|-) %{INT:response:int} (?:%{NOTSPACE:error_code}|-) (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) (?:%{INT:request_time_ms:int}|-) (?:%{INT:turnaround_time_ms:int}|-) (?:%{QS:referrer}|-) (?:%{QS:agent}|-) (?:%{NOTSPACE:version_id}|-)
+S3_ACCESS %{NOTSPACE:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{S3_OPERATION} %{NOTSPACE:key} (?:"%{S3_REQUEST_LINE}"|-) %{INT:response:int} %{NOTSPACE:error_code} (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) (?:%{INT:request_time_ms:int}|-) (?:%{INT:turnaround_time_ms:int}|-) %{QS:referrer} "?%{QS:agent}"? %{NOTSPACE:version_id}

--- a/patterns/s3
+++ b/patterns/s3
@@ -1,0 +1,7 @@
+S3_OP_TYPE SOAP|REST|WEBSITE
+
+S3_OPERATION %{S3_OP_TYPE:operation_type}\.%{WORD:operation}(\.%{WORD:resource_type})?
+
+S3_REQUEST_LINE (?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
+
+S3_ACCESS %{NOTSPACE:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{S3_OPERATION} %{NOTSPACE:key} "%{REQUEST_LINE}" %{INT:response:int} (?:%{NOTSPACE:error_code}|-) (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) %{INT:request_time_ms:int} (:?%{INT:turnaround_time_ms:int}|-) %{QS:referrer} %{QS:agent} (:?%{NOTSPACE:version_id}|-)

--- a/spec/filters/grok.rb
+++ b/spec/filters/grok.rb
@@ -500,4 +500,67 @@ describe LogStash::Filters::Grok do
       insist { subject["foo"] }.is_a?(String)
     end
   end
+
+  describe "s3 access log format" do
+    config <<-CONFIG
+      filter {
+        grok {
+          match => [ "message", "%{S3_ACCESS}" ]
+        }
+      }
+    CONFIG
+
+    sample "79a5 mybucket [06/Feb/2014:00:00:38 +0000] 192.0.2.3 79a5 3E57427F3EXAMPLE REST.GET.VERSIONING - \"GET /mybucket?versioning HTTP/1.1\" 200 - 113 - 7 - \"-\" \"S3Console/0.4\" -" do
+      insist { subject["tags"] }.nil?
+      insist { subject["owner"] } == "79a5"
+      insist { subject["bucket"] } == "mybucket"
+      insist { subject["timestamp"] } == "06/Feb/2014:00:00:38 +0000"
+      insist { subject["clientip"] } == "192.0.2.3"
+      insist { subject["requester"] } == "79a5"
+      insist { subject["request_id"] } == "3E57427F3EXAMPLE"
+      insist { subject["operation_type"] } == "REST"
+      insist { subject["operation"] } == "GET"
+      insist { subject["resource_type"] } == "VERSIONING"
+      insist { subject["key"] } == '-'
+      insist { subject["verb"] } == "GET"
+      insist { subject["request"] } == "/mybucket?versioning"
+      insist { subject["httpversion"] } == "1.1"
+      insist { subject["response"] } == 200
+      insist { subject["error_code"] } == "-"
+      insist { subject["bytes"] } == 113
+      insist { subject["object_size"] }.nil?
+      insist { subject["request_time_ms"] } == 7
+      insist { subject["turnaround_time_ms"] }.nil?
+      insist { subject["referrer"] } == "\"-\""
+      insist { subject["agent"] } == "\"S3Console/0.4\""
+      insist { subject["version_id"] } == "-"
+    end
+
+    sample "79a5 mybucket [12/May/2014:07:54:01 +0000] 10.0.1.2 - 7ACC4BE89EXAMPLE REST.GET.OBJECT foo/bar.html \"GET /foo/bar.html HTTP/1.1\" 304 - - 1718 10 - \"-\" \"Mozilla/5.0\" -" do
+      insist { subject["tags"] }.nil?
+      insist { subject["owner"] } == "79a5"
+      insist { subject["bucket"] } == "mybucket"
+      insist { subject["timestamp"] } == "12/May/2014:07:54:01 +0000"
+      insist { subject["clientip"] } == "10.0.1.2"
+      insist { subject["requester"] } == "-"
+      insist { subject["request_id"] } == "7ACC4BE89EXAMPLE"
+      insist { subject["operation_type"] } == "REST"
+      insist { subject["operation"] } == "GET"
+      insist { subject["resource_type"] } == "OBJECT"
+      insist { subject["key"] } == "foo/bar.html"
+      insist { subject["verb"] } == "GET"
+      insist { subject["request"] } == "/foo/bar.html"
+      insist { subject["httpversion"] } == "1.1"
+      insist { subject["response"] } == 304
+      insist { subject["error_code"] } == "-"
+      insist { subject["bytes"] }.nil?
+      insist { subject["object_size"] } == 1718
+      insist { subject["request_time_ms"] } == 10
+      insist { subject["turnaround_time_ms"] }.nil?
+      insist { subject["referrer"] } == "\"-\""
+      insist { subject["agent"] } == "\"Mozilla/5.0\""
+      insist { subject["version_id"] } == "-"
+    end
+  end
+
 end

--- a/spec/filters/grok.rb
+++ b/spec/filters/grok.rb
@@ -505,7 +505,7 @@ describe LogStash::Filters::Grok do
     config <<-CONFIG
       filter {
         grok {
-          match => [ "message", "%{S3_ACCESS}" ]
+          match => [ "message", "%{S3_ACCESS_LOG}" ]
         }
       }
     CONFIG
@@ -518,22 +518,20 @@ describe LogStash::Filters::Grok do
       insist { subject["clientip"] } == "192.0.2.3"
       insist { subject["requester"] } == "79a5"
       insist { subject["request_id"] } == "3E57427F3EXAMPLE"
-      insist { subject["operation_type"] } == "REST"
-      insist { subject["operation"] } == "GET"
-      insist { subject["resource_type"] } == "VERSIONING"
+      insist { subject["operation"] } == "REST.GET.VERSIONING"
       insist { subject["key"] } == '-'
       insist { subject["verb"] } == "GET"
       insist { subject["request"] } == "/mybucket?versioning"
       insist { subject["httpversion"] } == "1.1"
       insist { subject["response"] } == 200
-      insist { subject["error_code"] } == "-"
+      insist { subject["error_code"] }.nil?
       insist { subject["bytes"] } == 113
       insist { subject["object_size"] }.nil?
       insist { subject["request_time_ms"] } == 7
       insist { subject["turnaround_time_ms"] }.nil?
       insist { subject["referrer"] } == "\"-\""
       insist { subject["agent"] } == "\"S3Console/0.4\""
-      insist { subject["version_id"] } == "-"
+      insist { subject["version_id"] }.nil?
     end
 
     sample "79a5 mybucket [12/May/2014:07:54:01 +0000] 10.0.1.2 - 7ACC4BE89EXAMPLE REST.GET.OBJECT foo/bar.html \"GET /foo/bar.html HTTP/1.1\" 304 - - 1718 10 - \"-\" \"Mozilla/5.0\" -" do
@@ -544,22 +542,54 @@ describe LogStash::Filters::Grok do
       insist { subject["clientip"] } == "10.0.1.2"
       insist { subject["requester"] } == "-"
       insist { subject["request_id"] } == "7ACC4BE89EXAMPLE"
-      insist { subject["operation_type"] } == "REST"
-      insist { subject["operation"] } == "GET"
-      insist { subject["resource_type"] } == "OBJECT"
+      insist { subject["operation"] } == "REST.GET.OBJECT"
       insist { subject["key"] } == "foo/bar.html"
       insist { subject["verb"] } == "GET"
       insist { subject["request"] } == "/foo/bar.html"
       insist { subject["httpversion"] } == "1.1"
       insist { subject["response"] } == 304
-      insist { subject["error_code"] } == "-"
+      insist { subject["error_code"] }.nil?
       insist { subject["bytes"] }.nil?
       insist { subject["object_size"] } == 1718
       insist { subject["request_time_ms"] } == 10
       insist { subject["turnaround_time_ms"] }.nil?
       insist { subject["referrer"] } == "\"-\""
       insist { subject["agent"] } == "\"Mozilla/5.0\""
-      insist { subject["version_id"] } == "-"
+      insist { subject["version_id"] }.nil?
+    end
+  end
+
+  describe "elb access log format" do
+    config <<-CONFIG
+      filter {
+        grok {
+          match => ["message", "%{ELB_ACCESS_LOG}"]
+        }
+      }
+    CONFIG
+
+    sample "2014-02-15T23:39:43.945958Z my-test-loadbalancer 192.168.131.39:2817 10.0.0.1:80 0.000073 0.001048 0.000057 200 200 0 29 \"GET http://www.example.com:80/ HTTP/1.1\"" do
+      insist { subject["tags"] }.nil?
+      insist { subject["timestamp"] } == "2014-02-15T23:39:43.945958Z"
+      insist { subject["elb"] } == "my-test-loadbalancer"
+      insist { subject["clientip"] } == "192.168.131.39"
+      insist { subject["clientport"] } == 2817
+      insist { subject["backendip"] } == "10.0.0.1"
+      insist { subject["backendport"] } == 80
+      insist { subject["request_processing_time"] } == 0.000073
+      insist { subject["backend_processing_time"] } == 0.001048
+      insist { subject["response_processing_time"] } == 0.000057
+      insist { subject["response"] } == 200
+      insist { subject["backend_response"] } == 200
+      insist { subject["received_bytes"] } == 0
+      insist { subject["bytes"] } == 29
+      insist { subject["verb"] } == "GET"
+      insist { subject["request"] } == "http://www.example.com:80/"
+      insist { subject["proto"] } == "http"
+      insist { subject["httpversion"] } == "1.1"
+      insist { subject["urihost"] } == "www.example.com:80"
+      insist { subject["path"] } == "/"
+      insist { subject["params"] }.nil?
     end
   end
 


### PR DESCRIPTION
Add grok pattern to parse S3 access logs, http://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html, and ELB access logs, http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/access-log-collection.html.