### PR TITLE
S3 Output: Don't throw an error if there are no tags.

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -347,7 +347,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  def self.format_message(event)
     message = "Date: #{event["@timestamp"]}\n"
     message << "Source: #{event["source"]}\n"
-    message << "Tags: #{event["tags"].join(', ')}\n"
+    message << "Tags: #{event["tags"] ? event["tags"].join(', ') : ''}\n"
     message << "Fields: #{event.to_hash.inspect}\n"
     message << "Message: #{event["message"]}"
  end

--- a/spec/outputs/s3.rb
+++ b/spec/outputs/s3.rb
@@ -1,0 +1,33 @@
+require "test_utils"
+
+require "logstash/outputs/s3"
+require "rspec/mocks"
+
+describe LogStash::Outputs::S3 do
+  extend LogStash::RSpec
+
+  describe "format the message" do
+
+    it 'should not blow up if there are no tags' do
+      event = { "[@timestamp]" => "such timestamp",
+                "source" => "source wow",
+                "tags" => nil }
+      #event = double('event')
+      #event.should_receive(:[]).with('@timestamp')
+      #event.should_receive(:[]).with('source')
+      #event.should_receive(:[]).with('tags')
+      lambda {
+        LogStash::Outputs::S3.format_message(event)
+      }.should_not raise_error 
+    end
+
+    it 'should not blow up if there are tags' do
+      event = { "[@timestamp]" => "such timestamp",
+                "source" => "source wow",
+                "tags" => ['foo','bar'] }
+      lambda {
+        LogStash::Outputs::S3.format_message(event)
+    }.should_not raise_error 
+    end
+  end
+end


### PR DESCRIPTION
If you write S3 outputs and there are no tags, then it blows up
with #<NoMethodError: undefined method `join' for nil:NilClass>.

This PR fixes that, with tests.