### PR TITLE
Enabled dynamic strings for group name in ganglia output.

### DIFF
--- a/lib/logstash/outputs/ganglia.rb
+++ b/lib/logstash/outputs/ganglia.rb
@@ -36,7 +36,9 @@ class LogStash::Outputs::Ganglia < LogStash::Outputs::Base
   # Lifetime in seconds of this metric
   config :lifetime, :validate => :number, :default => 300
 
-  # Metric group
+  # Metric group. This supports dynamic strings like `%{node}`.
+  # Remember that in Ganglia metrics names have to differ
+  # even if groups names differ already.
   config :group, :validate => :string, :default => ""
 
   # Metric slope, represents metric behavior
@@ -66,7 +68,7 @@ class LogStash::Outputs::Ganglia < LogStash::Outputs::Base
       :units => @units,
       :type => @metric_type,
       :value => localvalue,
-      :group => @group,
+      :group => event.sprintf(@group),
       :slope => @slope,
       :tmax => @max_interval,
       :dmax => @lifetime


### PR DESCRIPTION
Attribute `group` attribute for Ganglia output could only be configured as static string. I added ability to use dynamic strings there, as in `name` parameter. I ran 'make test', which passed and I signed 'Individual Contributor License Agreement'.

Greetings,
Ewa.