### PR TITLE
S3 output critical race condition problem fixed

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -150,6 +150,8 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  config :canned_acl, :validate => ["private", "public_read", "public_read_write", "authenticated_read"],
         :default => "private"
 
+ config :temp_directory, :validate => :string, :default => "/opt/logstash/S3_temp/"
+
  # Method to set up the aws configuration and establish connection
  def aws_s3_config
 
@@ -259,7 +261,6 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  public
  def register
    require "aws-sdk"
-   @temp_directory = "/opt/logstash/S3_temp/"
    @lock = Mutex.new
 
    if (@tags.size != 0)

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -2,6 +2,7 @@
 require "logstash/outputs/base"
 require "logstash/namespace"
 require "socket" # for Socket.gethostname
+require "thread"
 
 # TODO integrate aws_config in the future
 #require "logstash/plugin_mixins/aws_config"
@@ -237,6 +238,11 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  # This method is used for create new empty temporary files for use. Flag is needed for indicate new subsection time_file.
  def newFile (flag)
 
+   if !@tempFile.nil?
+      @tempFile.close
+      @tempFile = nil
+   end
+
    if (flag == true)
      @current_final_path = getFinalPath
      @sizeCounter = 0
@@ -254,6 +260,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
  def register
    require "aws-sdk"
    @temp_directory = "/opt/logstash/S3_temp/"
+   @lock = Mutex.new
 
    if (@tags.size != 0)
        @tag_path = ""
@@ -282,8 +289,12 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
       @thread = time_alert(@time_file*60) do
        if (first_time == false)
          @logger.debug "S3: time_file triggered,  let's bucket the file if dosen't empty  and create new file "
-         upFile(false, File.basename(@tempFile))
-         newFile(true)
+         last_filename = nil
+         @lock.synchronize {
+            last_filename = File.basename(@tempFile)
+            newFile(true)
+         }
+         upFile(false, last_filename)
        else
          first_time = false
        end
@@ -311,35 +322,41 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
   # if specific the size
   if(size_file !=0)
+    size_under = false
+    @lock.synchronize {
+        size_under = @tempFile.size < @size_file
+    }
 
-    if (@tempFile.size < @size_file )
-
-       @logger.debug "S3: File have size: "+@tempFile.size.to_s+" and size_file is: "+ @size_file.to_s
-       @logger.debug "S3: put event into: "+File.basename(@tempFile)
+    if (size_under)
 
        # Put the event in the file, now!
-       File.open(@tempFile, 'a') do |file|
-         file.puts message
-         file.write "\n"
-       end
+       @lock.synchronize {
+         @logger.debug "S3: File have size: "+@tempFile.size.to_s+" and size_file is: "+ @size_file.to_s
+         @logger.debug "S3: put event into: "+File.basename(@tempFile)
+
+         @tempFile.puts message
+         @tempFile.write "\n"
+       }
 
      else
-
-       @logger.debug "S3: file: "+File.basename(@tempFile)+" is too large, let's bucket it and create new file"
-       upFile(false, File.basename(@tempFile))
-       @sizeCounter += 1
-       newFile(false)
-
+       last_filename = nil
+       @lock.synchronize {
+           @logger.debug "S3: file: "+File.basename(@tempFile)+" is too large, let's bucket it and create new file"
+           last_filename = File.basename(@tempFile)
+           @sizeCounter += 1
+           newFile(false)
+       }
+       upFile(false, last_filename)
      end
 
   # else we put all in one file
   else
 
-    @logger.debug "S3: put event into "+File.basename(@tempFile)
-    File.open(@tempFile, 'a') do |file|
-      file.puts message
-      file.write "\n"
-    end
+    @lock.synchronize {
+      @logger.debug "S3: put event into "+File.basename(@tempFile)
+      @tempFile.puts message
+      @tempFile.write "\n"
+    }
   end
 
  end


### PR DESCRIPTION
there was a critical problem in the logstash S3 output plugin that can cause data loss and data corruption of old logs; while rolling to the next file and uploading the last complete temp file into s3, output thread keeps writing to the file being uploaded. it could cause

 1. having some data appended after upload completion, which can cause data loss
 2. having some data appended even after the temp file has been deleted, which can cause some corrupted small sized file with the same name. If recovery flag is on, after logstash restart the small corrupted file will be uploaded into s3. This process will overwrite the original backup'ed files and cause the backup file loss (Our company has been heavily and pitifully affected by this)

We have written this patch which properly works with ruby file objects and use Mutex properly while rolling to the next temp file.
