### PR TITLE
Spool codec drops messages

### DIFF
--- a/lib/logstash/codecs/spool.rb
+++ b/lib/logstash/codecs/spool.rb
@@ -18,13 +18,13 @@ class LogStash::Codecs::Spool < LogStash::Codecs::Base
   public
   def encode(event)
     @buffer ||= []
+    @buffer << event
+
     #buffer size is hard coded for now until a
     #better way to pass args into codecs is implemented
     if @buffer.length >= @spool_size
       @on_event.call @buffer
       @buffer = []
-    else
-      @buffer << event
     end
   end # def encode
 


### PR DESCRIPTION
This was picked up by @piavlo when submitting a patch for the compressed spooler.

The spool codec has an algorithm something like:

1. Receive a message, and...
2. If the spool has more space, push it into a buffer.
3. Or if the spool is full, push the spool out over the network

The issue here is that at step 3, the message currently being handled is not added to a spool. So you end up losing messages.

See also https://github.com/elasticsearch/logstash-contrib/pull/111