### PR TITLE
Ganglia input: Store the value and ganglia name.

### DIFF
--- a/lib/logstash/inputs/ganglia.rb
+++ b/lib/logstash/inputs/ganglia.rb
@@ -115,7 +115,8 @@ class LogStash::Inputs::Ganglia < LogStash::Inputs::Base
 
       data["program"] = "ganglia"
       event["log_host"] = data["hostname"]
-      %w{dmax tmax slope type units}.each do |info|
+      event['val'] = data['val']
+      %w{dmax tmax slope type units name}.each do |info|
         event[info] = @metadata[data["name"]][info]
       end
       return event


### PR DESCRIPTION
Previously, we only had metadata in events, which wasn't very useful. An event would look like
this:

    {
          "@version" => "1",
        "@timestamp" => "2014-09-22T10:51:59.337Z",
          "log_host" => "example.com",
              "dmax" => 0,
              "tmax" => 90,
             "slope" => "both",
              "type" => "float",
             "units" => "%",
              "host" => "1.2.3.4"
    }

Events now look like this:

    {
          "@version" => "1",
        "@timestamp" => "2014-09-22T10:51:59.337Z",
          "log_host" => "example.com",
               "val" => 0.0, # added
              "dmax" => 0,
              "tmax" => 90,
             "slope" => "both",
              "type" => "float",
             "units" => "%",
              "name" => "cpu_nice", # added
              "host" => "1.2.3.4"
    }