### PR TITLE
[filter/metrics] Fix flushing in metrics filter

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -128,6 +128,10 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
   # The flush interval, when the metrics event is created. Must be a multiple of 5s.
   config :flush_interval, :validate => :number, :default => 5
 
+  # Call the filter flush method at regular interval.
+  # Optional.
+  config :periodic_flush, :validate => :boolean, :default => true
+
   # The clear interval, when all counter are reset.
   #
   # If set to -1, the default value, the metrics will never be cleared.
@@ -174,7 +178,7 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
     end
   end # def filter
 
-  def flush
+  def flush(options = {})
     # Add 5 seconds to @last_flush and @last_clear counters
     # since this method is called every 5 seconds.
     @last_flush.update { |v| v + 5 }

--- a/spec/filters/metrics_spec.rb
+++ b/spec/filters/metrics_spec.rb
@@ -230,4 +230,41 @@ describe LogStash::Filters::Metrics do
       insist {subject.register }.raises(LogStash::ConfigurationError)
     end
   end
+
+  context "should flush every 5 seconds when run in agent" do
+    require "tempfile"
+    tmp_file = Tempfile.new('logstash-spec-metrics-file')
+    config <<-CONFIG
+      input {
+       generator {
+         type => "generated"
+         count => 200000
+       }
+      }
+
+      filter {
+        if [type] == "generated" {
+          metrics {
+            meter => "events"
+            add_tag => "metric"
+          }
+        }
+      }
+
+      output {
+        #only emit events with the 'metric' tag
+        if "metric" in [tags] {
+          file {
+          path => "#{tmp_file.path}"
+        }
+        }
+      }
+    CONFIG
+
+    agent do
+      #Counting \n is counting events
+      #A unique event means no flushing occured before teardown
+      reject {tmp_file.read.scan(/\n/).count} == 1
+    end
+  end
 end


### PR DESCRIPTION
As discovered in #1805, metrics filter is not correctly flushing events

The current spec was calling flush manually not relying on the pipeline periodic_flusher threads, 
here is a proposal test case using the full agent to cover this case + fix to metrics filter based on the changed done to other flushing filters (multiline, spool) in #1545 