### PR TITLE
fix nologin path

### DIFF
--- a/pkg/debian/before-install.sh
+++ b/pkg/debian/before-install.sh
@@ -8,5 +8,5 @@ fi
 # create logstash user
 if ! getent passwd logstash >/dev/null; then
   useradd -M -r -g logstash -d /var/lib/logstash \
-    -s /sbin/nologin -c "LogStash Service User" logstash
+    -s /usr/sbin/nologin -c "LogStash Service User" logstash
 fi

--- a/pkg/ubuntu/before-install.sh
+++ b/pkg/ubuntu/before-install.sh
@@ -8,5 +8,5 @@ fi
 # create logstash user
 if ! getent passwd logstash >/dev/null; then
   useradd -M -r -g logstash -d /var/lib/logstash \
-    -s /sbin/nologin -c "LogStash Service User" logstash
+    -s /usr/sbin/nologin -c "LogStash Service User" logstash
 fi


### PR DESCRIPTION
Run the command:
``` sh
which nologin
``` 
then it return
 ``` sh
/usr/sbin/nologin
```

I test this on these linux distribution below:
* Debian 7
* Ubuntu 12.04 LTS
* Ubuntu 14.04 LTS