### PR TITLE
Strip support for non used JRuby versions and unused code (aka rdocs, ....)

### DIFF
--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -87,6 +87,7 @@ setup_ruby() {
 }
 
 jruby_opts() {
+  echo "--1.9"
   for i in $JAVA_OPTS ; do
     echo "-J$i"
   done

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -15,23 +15,23 @@ namespace "artifact" do
     ]
   end
 
-  def exclude_globs
-    return @exclude_globs if @exclude_globs
-    @exclude_globs = []
+  def exclude_paths
+    return @exclude_paths if @exclude_paths
+    @exclude_paths = []
     #gitignore = File.join(File.dirname(__FILE__), "..", ".gitignore")
     #if File.exists?(gitignore)
-      #@exclude_globs += File.read(gitignore).split("\n")
+      #@exclude_paths += File.read(gitignore).split("\n")
     #end
-    @exclude_globs << "spec/reports/**/*"
-    @exclude_globs << "**/*.gem"
-    @exclude_globs << "**/test/files/slow-xpath.xml"
-    @exclude_globs << "**/logstash-*/spec"
-    return @exclude_globs
+    @exclude_paths << "spec/reports/**/*"
+    @exclude_paths << "**/*.gem"
+    @exclude_paths << "**/test/files/slow-xpath.xml"
+    @exclude_paths << "**/logstash-*/spec"
+    return @exclude_paths
   end
 
   def excludes
     return @excludes if @excludes
-    @excludes = exclude_globs.collect { |g| Rake::FileList[g] }.flatten
+    @excludes = exclude_paths.collect { |g| Rake::FileList[g] }.flatten
   end
 
   def exclude?(path)

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -25,6 +25,7 @@ namespace "artifact" do
     @exclude_globs << "spec/reports/**/*"
     @exclude_globs << "**/*.gem"
     @exclude_globs << "**/test/files/slow-xpath.xml"
+    @exclude_globs << "**/logstash-*/spec"
     return @exclude_globs
   end
 

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -121,7 +121,6 @@ namespace "vendor" do
     Rake::Task["dependency:rbx-stdlib"] if LogStash::Environment.ruby_engine == "rbx"
     Rake::Task["dependency:stud"].invoke
     Rake::Task["vendor:bundle"].invoke("tools/Gemfile") if args.to_hash.empty? || args[:bundle]
-
   end # task gems
   task "all" => "gems"
 
@@ -146,6 +145,11 @@ namespace "vendor" do
       end
     end
 
+    # We aim to clean up specs within the logstash related projects, as we know they
+    # not necessary to have while packaging.
+    Dir.glob("vendor/bundle/jruby/*/gems/logstash-*/spec").each do |dir|
+      FileUtils.rm_rf(dir)
+    end
     # because --path creates a .bundle/config file and changes bundler path
     # we need to remove this file so it doesn't influence following bundler calls
     FileUtils.rm_rf(::File.join(LogStash::Environment::LOGSTASH_HOME, "tools/.bundle"))

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -144,12 +144,6 @@ namespace "vendor" do
         sleep(1)
       end
     end
-
-    # We aim to clean up specs within the logstash related projects, as we know they
-    # not necessary to have while packaging.
-    Dir.glob("vendor/bundle/jruby/*/gems/logstash-*/spec").each do |dir|
-      FileUtils.rm_rf(dir)
-    end
     # because --path creates a .bundle/config file and changes bundler path
     # we need to remove this file so it doesn't influence following bundler calls
     FileUtils.rm_rf(::File.join(LogStash::Environment::LOGSTASH_HOME, "tools/.bundle"))

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -71,6 +71,8 @@ namespace "vendor" do
     download = file_fetch(url, info["sha1"])
     parent = vendor(name).gsub(/\/$/, "")
     directory parent => "vendor" do
+      next if parent =~ /lib\/ruby\/1.8/
+      next if parent =~ /lib\/ruby\/2.0/
       mkdir parent
     end.invoke unless Rake::Task.task_defined?(parent)
 
@@ -79,6 +81,8 @@ namespace "vendor" do
       out = entry.full_name.gsub(prefix_re, "")
       next if out =~ /^samples/
       next if out =~ /@LongLink/
+      next if out =~ /lib\/ruby\/1.8/
+      next if out =~ /lib\/ruby\/2.0/
       vendor(name, out)
     end # untar
   end # jruby


### PR DESCRIPTION
With the aim to reduce unnecessary space, this PR fix some of this problems like:

* Strips support from the vendorized JRuby for 1.8 and 2.0 libs. 
* It makes sure that Logstash is run under the 1.9 mode.
* Remove unused gems like rdocs.
* Removed specs from logstash plugins.

Fits some points from  #2137 

 