### PR TITLE
Remove kafka input and output from default plugins packaging

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -64,11 +64,9 @@ logstash-input-gelf
 logstash-output-lumberjack
 logstash-input-generator
 logstash-input-graphite
-logstash-output-kafka
 logstash-input-imap
 logstash-input-irc
 logstash-output-juggernaut
-logstash-input-kafka
 logstash-input-log4j
 logstash-input-lumberjack
 logstash-input-pipe


### PR DESCRIPTION
With 1.5, kafka plugin can easily be installed using `bin/plugin install losgtash-input-kafka`. This will shave ~30mb from the LS release package. See #2137 