### PR TITLE
add support for :bytes validation to config

### DIFF
--- a/docs/asciidoc/static/configuration.asciidoc
+++ b/docs/asciidoc/static/configuration.asciidoc
@@ -188,6 +188,27 @@ Example:
   codec => "json"
 ----------------------------------
 
+[[bytes]]
+[float]
+==== Bytes
+
+A bytes field is a String field which represents a valid unit of bytes. It is a 
+convenient method for declaring specific sizes in your plugin options. Both SI(k M G T P E Z Y)
+and Binary(Ki Mi Gi Ti Pi Ei Zi Yi) units are supported. Binary units are in 
+base-1024, while SI units are in base-1000. This field is case-insensitive 
+and accepts space between the value and the unit. When no unit is specified, the integer string
+represents the number of bytes.
+
+Examples:
+
+[source,js]
+----------------------------------
+  my_bytes => "1113"   # 1113 bytes
+  my_bytes => "10MiB"  # 10485760 bytes
+  my_bytes => "100kib" # 102400 bytes
+  my_bytes => "180 mb" # 180000000 bytes
+----------------------------------
+
 
 [float]
 === Field References

--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -7,6 +7,7 @@ require "logstash/util/password"
 require "logstash/version"
 require "logstash/environment"
 require "logstash/util/plugin_version"
+require "filesize"
 
 LogStash::Environment.load_locale!
 
@@ -466,6 +467,13 @@ module LogStash::Config::Mixin
             end
 
             result = value.first
+          when :bytes
+            begin
+              bytes = Integer(value.first) rescue nil
+              result = bytes || Filesize.from(value.first).to_i
+            rescue ArgumentError
+              return false, "Unparseable filesize: #{value.first}. possible units (KiB, MiB, ...) e.g. '10 KiB'. doc reference: http://www.elasticsearch.org/guide/en/logstash/current/_logstash_config_language.html#bytes"
+            end
           else
             return false, "Unknown validator symbol #{validator}"
         end # case validator

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "pry"                   #(Ruby license)
   gem.add_runtime_dependency "stud"                  #(Apache 2.0 license)
   gem.add_runtime_dependency "clamp"                 #(MIT license) for command line args/flags
+  gem.add_runtime_dependency "filesize"              #(MIT license) for :bytes config validator
 
   # TODO(sissel): Treetop 1.5.x doesn't seem to work well, but I haven't
   # investigated what the cause might be. -Jordan

--- a/spec/core/config_mixin_spec.rb
+++ b/spec/core/config_mixin_spec.rb
@@ -1,0 +1,69 @@
+require "logstash/config/mixin"
+require "logstash/filters/base"
+
+describe LogStash::Config::Mixin do
+  context "when validating :bytes successfully" do
+    subject do
+      local_num_bytes = num_bytes # needs to be locally scoped :(
+      Class.new(LogStash::Filters::Base) do
+        include LogStash::Config::Mixin
+        config_name "test"
+        milestone 1
+        config :size_bytes, :validate => :bytes
+        config :size_default, :validate => :bytes, :default => "#{local_num_bytes}"
+        config :size_upcase, :validate => :bytes
+        config :size_downcase, :validate => :bytes
+        config :size_space, :validate => :bytes
+      end.new({
+        "size_bytes" => "#{local_num_bytes}",
+        "size_upcase" => "#{local_num_bytes}KiB".upcase,
+        "size_downcase" => "#{local_num_bytes}KiB".downcase,
+        "size_space" => "#{local_num_bytes} KiB"
+      })
+    end
+
+    let!(:num_bytes) { rand(1000) }
+    let!(:num_kbytes) { num_bytes * 1024 }
+
+    it "should validate :bytes successfully with no units" do
+      expect(subject.size_bytes).to eq(num_bytes)
+    end
+
+    it "should allow setting valid default" do
+      expect(subject.size_default).to eq(num_bytes)
+    end
+
+    it "should be case-insensitive when parsing units" do
+      expect(subject.size_upcase).to eq(num_kbytes)
+      expect(subject.size_downcase).to eq(num_kbytes)
+    end
+
+    it "should accept one space between num_bytes and unit suffix" do
+      expect(subject.size_space).to eq(num_kbytes)
+    end
+  end
+
+  context "when raising configuration errors while validating" do
+    it "should raise configuration error when provided with invalid units" do
+      expect {
+        Class.new(LogStash::Filters::Base) do
+          include LogStash::Config::Mixin
+          config_name "test"
+          milestone 1
+          config :size_file, :validate => :bytes
+        end.new({"size_file" => "10 yolobytes"})
+      }.to raise_error(LogStash::ConfigurationError)
+    end
+
+    it "should raise configuration error when provided with too many spaces" do
+      expect {
+        Class.new(LogStash::Filters::Base) do
+          include LogStash::Config::Mixin
+          config_name "test"
+          milestone 1
+          config :size_file, :validate => :bytes
+        end.new({"size_file" => "10  kib"})
+      }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+end


### PR DESCRIPTION
fixes issue https://github.com/elasticsearch/logstash/issues/1921

allows for friendlier config option for specifying file sizes.

```
...
config :file_size, :validate => :bytes, :default => "10Kib"`
...
# Now Obj.file_size == 10240
```

Currently uses the [Filesize](https://github.com/dominikh/filesize) rubygem to parse/validate the input.
This supports both IEC(Binary) and SI units

for more context on the different units: https://wiki.ubuntu.com/UnitsPolicy
