### PR TITLE
output: fix use of `exclude_tags` in output plugins

### DIFF
--- a/lib/logstash/outputs/base.rb
+++ b/lib/logstash/outputs/base.rb
@@ -112,7 +112,7 @@ class LogStash::Outputs::Base < LogStash::Plugin
 
     if !@exclude_tags.empty? && event["tags"]
       if @exclude_tags.send(@exclude_method) {|tag| event["tags"].include?(tag)}
-        @logger.debug? and @logger.debug("outputs/#{self.class.name}: Dropping event because tags contains excluded tags: #{exclude_tags.inspect}", event)
+        @logger.debug? and @logger.debug("outputs/#{self.class.name}: Dropping event because tags contains excluded tags: #{@exclude_tags.inspect}", event)
         return false
       end
     end


### PR DESCRIPTION
For people still using `exclude_tags` in their output configuration,
Logstash stops with an exception `TypeError: can't convert nil into
String`. Fix that by fixing the reference to `@exclude_tags`.