### PR TITLE
Use the gem specification from the plugin to display the version notice to the user

### DIFF
--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -199,7 +199,8 @@ module LogStash::Config::Mixin
       @logger = Cabin::Channel.get(LogStash)
       is_valid = true
 
-      is_valid &&= validate_plugin_version
+      print_version_notice
+
       is_valid &&= validate_check_invalid_parameter_names(params)
       is_valid &&= validate_check_required_parameter_names(params)
       is_valid &&= validate_check_parameter_values(params)
@@ -211,25 +212,28 @@ module LogStash::Config::Mixin
       specification = Gem::Specification.find_by_name(plugin_gem_name)
       major, minor, patch = specification.version.segments
 
-      Struct.new(:major, :minor, :patch)
-        .new(major, minor, patch)
+      return {
+        :major => major,
+        :minor => minor,
+        :patch => patch 
+      }
     end
 
     def plugin_gem_name
       [GEM_NAME_PREFIX, @plugin_type, @plugin_name].join('-')
     end
 
-    def validate_plugin_version
+    def print_version_notice
       return true if @@version_notice_given
 
-      if plugin_version.major < 1
-        if plugin_version.minor == 9
-          @logger.warn(I18n.t("logstash.plugin.version.0-9-0", 
+      if plugin_version[:major] < 1
+        if plugin_version[:minor] == 9
+          @logger.warn(I18n.t("logstash.plugin.version.0-9-x", 
                               :type => @plugin_type,
                               :name => @config_name,
                               :LOGSTASH_VERSION => LOGSTASH_VERSION))
         else
-          @logger.warn(I18n.t("logstash.plugin.version.0-1-0", 
+          @logger.warn(I18n.t("logstash.plugin.version.0-1-x", 
                               :type => @plugin_type,
                               :name => @config_name,
                               :LOGSTASH_VERSION => LOGSTASH_VERSION))

--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -132,6 +132,7 @@ module LogStash::Config::Mixin
     # Deprecated: Declare the version of the plugin
     # inside the gemspec.
     def milestone(m=nil)
+      @logger = Cabin::Channel.get(LogStash)
       @logger.error(I18n.t('logstash.plugin.deprecated'))
     end
 

--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -120,7 +120,7 @@ module LogStash::Config::Mixin
 
     # If name is given, set the name and return it.
     # If no name given (nil), return the current name.
-    def config_name(name=nil)
+    def config_name(name = nil)
       @config_name = name if !name.nil?
       LogStash::Config::Registry.registry[@config_name] = self
       return @config_name
@@ -128,13 +128,13 @@ module LogStash::Config::Mixin
 
     # Deprecated: Declare the version of the plugin
     # inside the gemspec.
-    def plugin_status(status=nil)
+    def plugin_status(status = nil)
       milestone(status)
     end
 
     # Deprecated: Declare the version of the plugin
     # inside the gemspec.
-    def milestone(m=nil)
+    def milestone(m = nil)
       @logger = Cabin::Channel.get(LogStash)
       @logger.error(I18n.t('logstash.plugin.deprecated_milestone', :plugin => config_name))
     end

--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -6,6 +6,8 @@ require "logstash/logging"
 require "logstash/util/password"
 require "logstash/version"
 require "logstash/environment"
+require "logstash/util/plugin_version"
+
 LogStash::Environment.load_locale!
 
 # This module is meant as a mixin to classes wishing to be configurable from
@@ -212,11 +214,7 @@ module LogStash::Config::Mixin
       specification = Gem::Specification.find_by_name(plugin_gem_name)
       major, minor, patch = specification.version.segments
 
-      return {
-        :major => major,
-        :minor => minor,
-        :patch => patch 
-      }
+      return LogStash::Util::PluginVersion.new(major, minor, patch)
     end
 
     def plugin_gem_name
@@ -226,8 +224,8 @@ module LogStash::Config::Mixin
     def print_version_notice
       return true if @@version_notice_given
 
-      if plugin_version[:major] < 1
-        if plugin_version[:minor] == 9
+      if plugin_version.major < 1
+        if plugin_version.minor == 9
           @logger.warn(I18n.t("logstash.plugin.version.0-9-x", 
                               :type => @plugin_type,
                               :name => @config_name,

--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -133,7 +133,7 @@ module LogStash::Config::Mixin
     # inside the gemspec.
     def milestone(m=nil)
       @logger = Cabin::Channel.get(LogStash)
-      @logger.error(I18n.t('logstash.plugin.deprecated'))
+      @logger.error(I18n.t('logstash.plugin.deprecated_milestone', :plugin => config_name))
     end
 
     # Define a new configuration setting

--- a/lib/logstash/errors.rb
+++ b/lib/logstash/errors.rb
@@ -5,6 +5,7 @@ module LogStash
   class ConfigurationError < Error; end
   class PluginLoadingError < Error; end
   class ShutdownSignal < StandardError; end
+  class PluginNoVersionError < Error; end
 
   class Bug < Error; end
   class ThisMethodWasRemoved < Bug; end

--- a/lib/logstash/util/plugin_version.rb
+++ b/lib/logstash/util/plugin_version.rb
@@ -1,1 +1,43 @@
-LogStash::Util::PluginVersion = Struct.new(:major, :minor, :patch)
+require 'logstash/errors'
+require 'rubygems/version'
+require 'forwardable'
+
+module LogStash::Util
+  class PluginVersion
+    extend Forwardable
+    include Comparable
+
+    GEM_NAME_PREFIX = 'logstash'
+
+    def_delegators :@version, :to_s
+    attr_reader :version
+
+    def initialize(*options)
+      if options.size == 1 && options.first.is_a?(Gem::Version)
+        @version = options.first
+      else
+        @version = Gem::Version.new(options.join('.'))
+      end
+    end
+
+    def self.find_version!(name)
+      begin
+        specification = Gem::Specification.find_by_name(name)
+        new(specification.version)
+      rescue Gem::LoadError
+        # Rescuing the LoadError and raise a Logstash specific error.
+        # Likely we can't find the gem in the current GEM_PATH
+        raise LogStash::PluginNoVersionError
+      end
+    end
+
+    def self.find_plugin_version!(type, name)
+      plugin_name = [GEM_NAME_PREFIX, type, name].join('-')
+      find_version!(plugin_name)
+    end
+
+    def <=>(obj)
+      version <=> obj.version
+    end
+  end
+end

--- a/lib/logstash/util/plugin_version.rb
+++ b/lib/logstash/util/plugin_version.rb
@@ -36,8 +36,8 @@ module LogStash::Util
       find_version!(plugin_name)
     end
 
-    def <=>(obj)
-      version <=> obj.version
+    def <=>(other)
+      version <=> other.version
     end
   end
 end

--- a/lib/logstash/util/plugin_version.rb
+++ b/lib/logstash/util/plugin_version.rb
@@ -1,0 +1,1 @@
+LogStash::Util::PluginVersion = Struct.new(:major, :minor, :patch)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -38,6 +38,9 @@ en:
         %{plugin} plugin is using the 'milestone' method to declare the version
         of the plugin this method is deprecated in favor of declaring the
         version inside the gemspec.
+      no_version: >-
+        %{name} plugin doesn't have a version. This plugin isn't well
+         supported by the community and likely has no maintainer.
       version:
         0-9-x:
          Using version 0.9.x %{type} plugin '%{name}'. This plugin should work but

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -40,16 +40,12 @@ en:
         version inside the gemspec.
       version:
         0-9-0:
-         Using version 0.9.x %{type} plugin '%{name}'. This plugin should but
+         Using version 0.9.x %{type} plugin '%{name}'. This plugin should work but
          would benefit from use by folks like you. Please let us know if you
-         find bugs or have suggestions on how to improve this plugin. For more
-         information on plugin milestones, see
-         http://logstash.net/docs/%{LOGSTASH_VERSION}/plugin-version
+         find bugs or have suggestions on how to improve this plugin.
         0-1-0: >-
          Using version 0.1.x %{type} plugin '%{name}'. This plugin isn't well
-         supported by the community and likely has no maintainer. For more
-         information on plugin milestones, see
-         http://logstash.net/docs/%{LOGSTASH_VERSION}/plugin-version
+         supported by the community and likely has no maintainer.
     agent:
       sighup: >-
         SIGHUP received.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -39,11 +39,11 @@ en:
         of the plugin this method is deprecated in favor of declaring the
         version inside the gemspec.
       version:
-        0-9-0:
+        0-9-x:
          Using version 0.9.x %{type} plugin '%{name}'. This plugin should work but
          would benefit from use by folks like you. Please let us know if you
          find bugs or have suggestions on how to improve this plugin.
-        0-1-0: >-
+        0-1-x: >-
          Using version 0.1.x %{type} plugin '%{name}'. This plugin isn't well
          supported by the community and likely has no maintainer.
     agent:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -34,23 +34,22 @@ en:
         supported by this plugin. I will continue working as if you had not set
         this setting.
     plugin:
-      milestone:
-        "0": >-
-          Using milestone 0 %{type} plugin '%{name}'. This plugin isn't well
-          supported by the community and likely has no maintainer. For more
-          information on plugin milestones, see
-          http://logstash.net/docs/%{LOGSTASH_VERSION}/plugin-milestones
-        "1": >-
-          Using milestone 1 %{type} plugin '%{name}'. This plugin should work,
-          but would benefit from use by folks like you. Please let us know if you
-          find bugs or have suggestions on how to improve this plugin.  For more
-          information on plugin milestones, see
-          http://logstash.net/docs/%{LOGSTASH_VERSION}/plugin-milestones
-        "2": >-
-          Using milestone 2 %{type} plugin '%{name}'. This plugin should be
-          stable, but if you see strange behavior, please let us know!
-          For more information on plugin milestones, see
-          http://logstash.net/docs/%{LOGSTASH_VERSION}/plugin-milestones
+      deprecated_milestone: >-
+        %{plugin} plugin is using the 'milestone' method to declare the version
+        of the plugin this method is deprecated in favor of declaring the
+        version inside the gemspec.
+      version:
+        0-9-0:
+         Using version 0.9.x %{type} plugin '%{name}'. This plugin should but
+         would benefit from use by folks like you. Please let us know if you
+         find bugs or have suggestions on how to improve this plugin. For more
+         information on plugin milestones, see
+         http://logstash.net/docs/%{LOGSTASH_VERSION}/plugin-version
+        0-1-0: >-
+         Using version 0.1.x %{type} plugin '%{name}'. This plugin isn't well
+         supported by the community and likely has no maintainer. For more
+         information on plugin milestones, see
+         http://logstash.net/docs/%{LOGSTASH_VERSION}/plugin-version
     agent:
       sighup: >-
         SIGHUP received.

--- a/spec/core/plugin_spec.rb
+++ b/spec/core/plugin_spec.rb
@@ -84,5 +84,15 @@ describe LogStash::Plugin do
       LogStash::Filters::Stromae.validate({})
       LogStash::Filters::Stromae.validate({})
     end
+
+    it 'logs an error if the plugin use the milestone option' do
+      expect_any_instance_of(Cabin::Channel).to receive(:error)
+        .with(/stromae plugin is using the 'milestone' method/)
+
+      class LogStash::Filters::Stromae < LogStash::Filters::Base
+        config_name "stromae"
+        milestone 2
+      end
+    end
   end
 end

--- a/spec/core/plugin_spec.rb
+++ b/spec/core/plugin_spec.rb
@@ -69,7 +69,7 @@ describe LogStash::Plugin do
     end
 
     it "doesnt show the version notice more than once" do
-      class LogStash::Filters::Stromae < LogStash::Filters::Base
+      one_notice = Class.new(LogStash::Filters::Base) do
         config_name "stromae"
       end
 
@@ -81,8 +81,8 @@ describe LogStash::Plugin do
         .once
         .with(/Using version 0.1.x/)
 
-      LogStash::Filters::Stromae.validate({})
-      LogStash::Filters::Stromae.validate({})
+      one_notice.validate({})
+      one_notice.validate({})
     end
 
     it 'logs an error if the plugin use the milestone option' do

--- a/spec/core/plugin_spec.rb
+++ b/spec/core/plugin_spec.rb
@@ -85,6 +85,15 @@ describe LogStash::Plugin do
       one_notice.validate({})
     end
 
+    it "warns the user if we can't find a defined version" do
+      expect_any_instance_of(Cabin::Channel).to receive(:warn)
+        .once
+        .with(/plugin doesn't have a version/)
+
+      subject.validate({})
+    end
+    
+
     it 'logs an error if the plugin use the milestone option' do
       expect_any_instance_of(Cabin::Channel).to receive(:error)
         .with(/stromae plugin is using the 'milestone' method/)

--- a/spec/util/plugin_version_spec.rb
+++ b/spec/util/plugin_version_spec.rb
@@ -1,0 +1,13 @@
+require "logstash/util/plugin_version"
+
+describe LogStash::Util::PluginVersion do
+  subject { LogStash::Util::PluginVersion }
+
+  it 'contains the semver parts of a plugin version' do
+    version = subject.new(1, 2, 3)
+
+    expect(version.major).to eq(1)
+    expect(version.minor).to eq(2)
+    expect(version.patch).to eq(3)
+  end
+end

--- a/spec/util/plugin_version_spec.rb
+++ b/spec/util/plugin_version_spec.rb
@@ -1,13 +1,48 @@
 require "logstash/util/plugin_version"
+require "logstash/errors"
 
 describe LogStash::Util::PluginVersion do
   subject { LogStash::Util::PluginVersion }
 
-  it 'contains the semver parts of a plugin version' do
-    version = subject.new(1, 2, 3)
+  context "#find_version!" do
+    it 'raises an PluginNoVersionError if we cant find the plugin in the gem path' do
+      dummy_name ='this-character-doesnt-exist-in-the-marvel-universe'
+      expect { subject.find_version!(dummy_name) }.to raise_error(LogStash::PluginNoVersionError)
+    end
 
-    expect(version.major).to eq(1)
-    expect(version.minor).to eq(2)
-    expect(version.patch).to eq(3)
+    it 'returns the version of the gem' do
+      expect { subject.find_version!('bundler') }.not_to raise_error
+    end
+  end
+
+  context "#new" do
+    it 'accepts a Gem::Version instance as argument' do
+      version = Gem::Version.new('1.0.1')
+      expect(subject.new(version).to_s).to eq(version.to_s)
+    end
+
+    it 'accepts an array for defining the version' do
+      version = subject.new(1, 0, 2)
+      expect(version.to_s).to eq('1.0.2')
+    end
+  end
+
+  context "When comparing instances" do
+    it 'allow to check if the version is newer or older' do
+      old_version = subject.new(0, 1, 0)
+      new_version = subject.new(1, 0, 1)
+
+      expect(old_version).to be < new_version
+      expect(old_version).to be <= new_version
+      expect(new_version).to be > old_version
+      expect(new_version).to be >= old_version
+    end
+
+    it 'return true if the version are equal' do
+      version1 = subject.new(0, 1, 0)
+      version2 = subject.new(0, 1, 0)
+
+      expect(version1).to eq(version2)
+    end
   end
 end

--- a/tools/Gemfile.plugins.jruby-1.9.lock
+++ b/tools/Gemfile.plugins.jruby-1.9.lock
@@ -5,9 +5,9 @@ PATH
       cabin (>= 0.6.0)
       ci_reporter (= 1.9.3)
       clamp
-      file-dependencies
       ftw (~> 0.0.40)
       i18n (= 0.6.9)
+      insist (= 1.0.0)
       jar-dependencies (= 0.1.2)
       jrjackson
       jruby-httpclient
@@ -70,8 +70,6 @@ GEM
     ffi (1.9.6-java)
     ffi-rzmq (1.0.0)
       ffi
-    file-dependencies (0.1.4)
-      minitar
     filewatch (0.5.1)
     ftw (0.0.42)
       addressable
@@ -92,11 +90,16 @@ GEM
     ice_nine (0.11.1)
     insist (1.0.0)
     jar-dependencies (0.1.2)
+    jbundler (0.5.5)
+      bundler (~> 1.5)
+      ruby-maven (>= 3.1.1.0.1, < 3.1.2)
     jls-grok (0.11.0)
       cabin (>= 0.6.0)
     jls-lumberjack (0.0.20)
-    jrjackson (0.2.8)
+    jrjackson (0.2.7)
     jruby-httpclient (1.1.1-java)
+    jruby-kafka (0.2.1-java)
+      jbundler (= 0.5.5)
     jruby-win32ole (0.8.5)
     json (1.8.1-java)
     logstash-codec-collectd (0.1.2)
@@ -140,9 +143,8 @@ GEM
     logstash-codec-rubydebug (0.1.4)
       awesome_print
       logstash (>= 1.4.0, < 2.0.0)
-    logstash-devutils (0.0.7-java)
+    logstash-devutils (0.0.6-java)
       gem_publisher
-      insist (= 1.0.0)
       jar-dependencies
       minitar
       rake
@@ -250,6 +252,12 @@ GEM
     logstash-input-irc (0.1.1)
       cinch
       logstash (>= 1.4.0, < 2.0.0)
+      logstash-codec-plain
+    logstash-input-kafka (0.1.5)
+      jar-dependencies (~> 0.1.0)
+      jruby-kafka (>= 0.2.1)
+      logstash (>= 1.4.0, < 2.0.0)
+      logstash-codec-json
       logstash-codec-plain
     logstash-input-log4j (0.1.1)
       jar-dependencies
@@ -364,6 +372,12 @@ GEM
     logstash-output-juggernaut (0.1.1)
       logstash (>= 1.4.0, < 2.0.0)
       redis
+    logstash-output-kafka (0.1.3)
+      jar-dependencies
+      jruby-kafka (>= 0.2.1)
+      logstash (>= 1.4.0, < 2.0.0)
+      logstash-codec-json
+      logstash-codec-plain
     logstash-output-lumberjack (0.1.2)
       jls-lumberjack (>= 0.0.20)
       logstash (>= 1.4.0, < 2.0.0)
@@ -499,7 +513,7 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     user_agent_parser (2.2.0)
-    virtus (1.0.4)
+    virtus (1.0.3)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
@@ -561,6 +575,7 @@ DEPENDENCIES
   logstash-input-graphite
   logstash-input-imap
   logstash-input-irc
+  logstash-input-kafka
   logstash-input-log4j
   logstash-input-lumberjack
   logstash-input-pipe
@@ -590,6 +605,7 @@ DEPENDENCIES
   logstash-output-http
   logstash-output-irc
   logstash-output-juggernaut
+  logstash-output-kafka
   logstash-output-lumberjack
   logstash-output-nagios
   logstash-output-nagios_nsca

--- a/tools/Gemfile.plugins.jruby-1.9.lock
+++ b/tools/Gemfile.plugins.jruby-1.9.lock
@@ -5,9 +5,9 @@ PATH
       cabin (>= 0.6.0)
       ci_reporter (= 1.9.3)
       clamp
+      file-dependencies
       ftw (~> 0.0.40)
       i18n (= 0.6.9)
-      insist (= 1.0.0)
       jar-dependencies (= 0.1.2)
       jrjackson
       jruby-httpclient
@@ -70,6 +70,8 @@ GEM
     ffi (1.9.6-java)
     ffi-rzmq (1.0.0)
       ffi
+    file-dependencies (0.1.4)
+      minitar
     filewatch (0.5.1)
     ftw (0.0.42)
       addressable
@@ -90,16 +92,11 @@ GEM
     ice_nine (0.11.1)
     insist (1.0.0)
     jar-dependencies (0.1.2)
-    jbundler (0.5.5)
-      bundler (~> 1.5)
-      ruby-maven (>= 3.1.1.0.1, < 3.1.2)
     jls-grok (0.11.0)
       cabin (>= 0.6.0)
     jls-lumberjack (0.0.20)
-    jrjackson (0.2.7)
+    jrjackson (0.2.8)
     jruby-httpclient (1.1.1-java)
-    jruby-kafka (0.2.1-java)
-      jbundler (= 0.5.5)
     jruby-win32ole (0.8.5)
     json (1.8.1-java)
     logstash-codec-collectd (0.1.2)
@@ -143,8 +140,9 @@ GEM
     logstash-codec-rubydebug (0.1.4)
       awesome_print
       logstash (>= 1.4.0, < 2.0.0)
-    logstash-devutils (0.0.6-java)
+    logstash-devutils (0.0.7-java)
       gem_publisher
+      insist (= 1.0.0)
       jar-dependencies
       minitar
       rake
@@ -252,12 +250,6 @@ GEM
     logstash-input-irc (0.1.1)
       cinch
       logstash (>= 1.4.0, < 2.0.0)
-      logstash-codec-plain
-    logstash-input-kafka (0.1.5)
-      jar-dependencies (~> 0.1.0)
-      jruby-kafka (>= 0.2.1)
-      logstash (>= 1.4.0, < 2.0.0)
-      logstash-codec-json
       logstash-codec-plain
     logstash-input-log4j (0.1.1)
       jar-dependencies
@@ -372,12 +364,6 @@ GEM
     logstash-output-juggernaut (0.1.1)
       logstash (>= 1.4.0, < 2.0.0)
       redis
-    logstash-output-kafka (0.1.3)
-      jar-dependencies
-      jruby-kafka (>= 0.2.1)
-      logstash (>= 1.4.0, < 2.0.0)
-      logstash-codec-json
-      logstash-codec-plain
     logstash-output-lumberjack (0.1.2)
       jls-lumberjack (>= 0.0.20)
       logstash (>= 1.4.0, < 2.0.0)
@@ -513,7 +499,7 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     user_agent_parser (2.2.0)
-    virtus (1.0.3)
+    virtus (1.0.4)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
@@ -575,7 +561,6 @@ DEPENDENCIES
   logstash-input-graphite
   logstash-input-imap
   logstash-input-irc
-  logstash-input-kafka
   logstash-input-log4j
   logstash-input-lumberjack
   logstash-input-pipe
@@ -605,7 +590,6 @@ DEPENDENCIES
   logstash-output-http
   logstash-output-irc
   logstash-output-juggernaut
-  logstash-output-kafka
   logstash-output-lumberjack
   logstash-output-nagios
   logstash-output-nagios_nsca


### PR DESCRIPTION
We will need to update all the plugins to remove the milestone option and adjust the version in the gemspec