### PR TITLE
Add logstash-codec-cef to the plugins:all exclude

### DIFF
--- a/tools/Gemfile.plugins.all
+++ b/tools/Gemfile.plugins.all
@@ -1,5 +1,5 @@
 require 'octokit'
-skiplist = ['logstash-input-gemfire', 'logstash-output-gemfire', 'logstash-input-couchdb_changes', 'logstash-filter-metricize', 'logstash-filter-yaml']
+skiplist = ['logstash-codec-cef', 'logstash-input-gemfire', 'logstash-output-gemfire', 'logstash-input-couchdb_changes', 'logstash-filter-metricize', 'logstash-filter-yaml']
 
 source 'https://rubygems.org'
 


### PR DESCRIPTION
The plugin logstash-codec-cef is still not released to rubygems, so when the install plugin:all command need to have this into his exclude filter.

Otherwise is not possible to fetch all plugins at once as expected.