### PR TITLE
Add back kafka to default packaging. Was removed in 2320

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -64,9 +64,11 @@ logstash-input-gelf
 logstash-output-lumberjack
 logstash-input-generator
 logstash-input-graphite
+logstash-output-kafka
 logstash-input-imap
 logstash-input-irc
 logstash-output-juggernaut
+logstash-input-kafka
 logstash-input-log4j
 logstash-input-lumberjack
 logstash-input-pipe


### PR DESCRIPTION
With #2320, Kafka was removed from the default install list to save ~30mb from the LS release package. 

We had a discussion internally and arguments were made for having Kafka included back to make it consistent with the other packaged plugins. Moving forward (post v1.5), the idea is to have Logstash ship with a small list of plugins by default to reduce the install size. This would also allow users to only install plugins which are needed for their use-case. This is made easier by the recent plugin management infrastructure which can add/remove plugins at any time. Once we have more data on which plugins are popular, we will open an issue to only include those in the default package. Until then Kafka stays