### PR TITLE
Plugins to install also the plugins development dependencies

### DIFF
--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -12,6 +12,8 @@ module LogStash
     GEMFILE_PATH = ::File.join(LOGSTASH_HOME, "tools", "Gemfile")
     BOOTSTRAP_GEM_PATH = ::File.join(LOGSTASH_HOME, 'build', 'bootstrap')
 
+    LOGSTASH_ENV = (ENV["LS_ENV"] || 'production').to_s.freeze
+
     # loads currently embedded elasticsearch jars
     # @raise LogStash::EnvironmentError if not running under JRuby or if no jar files are found
     def load_elasticsearch_jars!
@@ -31,6 +33,10 @@ module LogStash
 
     def logstash_gem_home
       ::File.join(BUNDLE_DIR, ruby_engine, gem_ruby_version)
+    end
+
+    def env
+      LOGSTASH_ENV
     end
 
     # set GEM_PATH for logstash runtime

--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -39,6 +39,18 @@ module LogStash
       LOGSTASH_ENV
     end
 
+    def production?
+      env.downcase == "production"
+    end
+
+    def development?
+      env.downcase == "development"
+    end
+
+    def test?
+      env.downcase == "test"
+    end
+
     # set GEM_PATH for logstash runtime
     # GEM_PATH should include the logstash gems, the plugin gems and the bootstrap gems.
     # the bootstrap gems are required specificly for bundler which is a runtime dependency

--- a/lib/logstash/pluginmanager/install.rb
+++ b/lib/logstash/pluginmanager/install.rb
@@ -57,8 +57,15 @@ class LogStash::PluginManager::Install < Clamp::Command
     options = {}
     options[:document] = []
     if LogStash::Environment.test?
-      # More info on what do this options means
-      # https://github.com/rubygems/rubygems/blob/master/lib/rubygems/dependency_installer.rb#L56
+      # This two options are the ones used to ask the rubygems to install
+      # all development dependencies as you can do from the command line
+      # tool.
+      #
+      # Comments from the command line tool.
+      # --development     - Install additional development dependencies
+      #
+      # Links: https://github.com/rubygems/rubygems/blob/master/lib/rubygems/install_update_options.rb#L150
+      #        http://guides.rubygems.org/command-reference/#gem-install
       options[:dev_shallow] = true
       options[:development] = true
     end

--- a/lib/logstash/pluginmanager/install.rb
+++ b/lib/logstash/pluginmanager/install.rb
@@ -56,7 +56,9 @@ class LogStash::PluginManager::Install < Clamp::Command
     FileDependencies::Gem.hook
     options = {}
     options[:document] = []
-    if  LogStash::Environment.env == 'test'
+    if LogStash::Environment.test?
+      # More info on what do this options means
+      # https://github.com/rubygems/rubygems/blob/master/lib/rubygems/dependency_installer.rb#L56
       options[:dev_shallow] = true
       options[:development] = true
     end

--- a/lib/logstash/pluginmanager/install.rb
+++ b/lib/logstash/pluginmanager/install.rb
@@ -61,6 +61,9 @@ class LogStash::PluginManager::Install < Clamp::Command
       # all development dependencies as you can do from the command line
       # tool.
       #
+      # :development option for installing development dependencies.
+      # :dev_shallow option for checking on the top level gems if there.
+      #
       # Comments from the command line tool.
       # --development     - Install additional development dependencies
       #

--- a/lib/logstash/pluginmanager/install.rb
+++ b/lib/logstash/pluginmanager/install.rb
@@ -56,6 +56,10 @@ class LogStash::PluginManager::Install < Clamp::Command
     FileDependencies::Gem.hook
     options = {}
     options[:document] = []
+    if  LogStash::Environment.env == 'test'
+      options[:dev_shallow] = true
+      options[:development] = true
+    end
     inst = Gem::DependencyInstaller.new(options)
     inst.install plugin, version
     specs = inst.installed_gems.detect { |gemspec| gemspec.name == gem_meta.name }


### PR DESCRIPTION
While testing plugin installation are expected, for now to have also their development dependencies installed. 

This is like this because the way we do testing right now, actually this problem raised when testing https://github.com/logstash-plugins/logstash-output-email/blob/master/logstash-output-email.gemspec#L28 as the rumbster dependency was not installed.

To do that change in the plugin manager is easy, as we can see in this PR, but to do that using bundler is really no possible (or at less I was not able to see the way)

There is also a subtle change here, that the introduction of an event variable, so we are able to install plugins while testing with dev_deps, but not while in production (released status)