### PR TITLE
Workaround - Rake task that add development dependencies for testing into  a Gemfile

### DIFF
--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -23,7 +23,6 @@ namespace "plugin" do
 
   task "install-all" => [ "dependency:octokit" ] do
     Rake::Task["vendor:bundle"].invoke("tools/Gemfile.plugins.all")
-    Rake::Task["vendor:deps"].invoke("tools/Gemfile.plugins.all")
   end
 
 end # namespace "plugin"

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -23,7 +23,7 @@ namespace "plugin" do
 
   task "install-all" => [ "dependency:octokit" ] do
     Rake::Task["vendor:bundle"].invoke("tools/Gemfile.plugins.all")
+    Rake::Task["vendor:deps"].invoke("tools/Gemfile.plugins.all")
   end
-
 
 end # namespace "plugin"

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -19,7 +19,7 @@ namespace "test" do
   task "all-plugins" => [ "bootstrap","plugin:install-all" ] do
     require "logstash/environment"
     gem_home = LogStash::Environment.logstash_gem_home
-    pattern = "#{gem_home}/logstash-*/spec/{input,filter,codec,output}s/*_spec.rb"
+    pattern = "#{gem_home}/gems/logstash-*/spec/{input,filter,codec,output}s/*_spec.rb"
     sh "#{LogStath::Environment::LOGSTASH_HOME}/bin/logstash rspec --order rand #{pattern}"
   end
 

--- a/rakelib/vendor.rake
+++ b/rakelib/vendor.rake
@@ -124,30 +124,26 @@ namespace "vendor" do
   end # task gems
   task "all" => "gems"
 
-  task "deps", [:gemfile] => [ "dependency:bundler" ] do |task, args|
-    dependencies = {}
+  task "append_development_dependencies", [:gemfile] do |task, args|
+    dependencies = []
     # grab the development dependencies
-    Dir.glob("vendor/bundle/jruby/*/gems/logstash-*/*.gemspec") do |gemspec|
+    gem_home = LogStash::Environment.logstash_gem_home
+    Dir.glob("#{gem_home}/gems/logstash-*/*.gemspec") do |gemspec|
       spec = Gem::Specification.load(gemspec)
       spec.development_dependencies.each do |dependency|
-        dependencies[dependency.name] = dependency
+        dependencies << dependency
       end
     end
     deps_gemfile = args[:gemfile]
-    temp_data    = File.read(deps_gemfile)
     # generate the gemfile.
     File.open(deps_gemfile, "a") do |file|
-      dependencies.values.each do |dependency|
+      dependencies.each do |dependency|
         next if dependency.name.start_with?('logstash-')
         requirements = dependency.requirement.to_s.split(',').map { |s| "'#{s.strip}'" }.join(',')
         s =  "gem '#{dependency.name}', #{requirements}"
         file.puts s
       end
     end
-    # run bundle install with this new gemfile
-    Rake::Task["vendor:bundle"].invoke(deps_gemfile)
-    FileUtils.rm(deps_gemfile)
-    File.write(deps_gemfile, temp_data)
   end
 
   task "bundle", [:gemfile] => [ "dependency:bundler" ] do |task, args|


### PR DESCRIPTION
Rake task that source the currently installed dependencies and updated a Gemfile, so they can be installed and available for testing.

While not necessary a very optimal solution this helps to run all specs coming from plugins all at once with a given logstash version.

# Workflow example.

* ```rake plugin:install-all```
* ```rake vendor:append_development_dependencies\[tools/Gemfile.plugins.all\]```
* ```rake plugin:install-all```

will basically add all the plugins, then append the development dependencies to the Gemfile.plugins.all and run again the plugin:install-all.

## Note

For now ```rake plugin:install-all``` is also installing the development dependencies in order to adapt it to the comments coming from @electrical, we should decide on one way and remove the other. So this workflow for now is doing something else too.