### PR TITLE
Test Coverage reenabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Logstash [![Code Climate](https://codeclimate.com/github/elasticsearch/logstash/badges/gpa.svg)](https://codeclimate.com/github/elasticsearch/logstash)
+# Logstash [![Code Climate](https://codeclimate.com/github/elasticsearch/logstash/badges/gpa.svg)](https://codeclimate.com/github/elasticsearch/logstash) [![Coverage Status](https://coveralls.io/repos/elasticsearch/logstash/badge.svg)](https://coveralls.io/r/elasticsearch/logstash)
 
 Logstash is a tool for managing events and logs. You can use it to collect
 logs, parse them, and store them for later use (like, for searching). Speaking

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -75,8 +75,4 @@ Gem::Specification.new do |gem|
 
   # Jenkins Deps
   gem.add_runtime_dependency "ci_reporter", "1.9.3"
-
-  # Development Deps
-  # coveralls temporarily disabled because of Bundler bug with "without development" and gemspec
-  # gem.add_development_dependency "coveralls"
 end

--- a/spec/core/conditionals_spec.rb
+++ b/spec/core/conditionals_spec.rb
@@ -1,4 +1,4 @@
-require "logstash/devutils/rspec/spec_helper"
+require 'spec_helper'
 
 module ConditionalFanciness
   def description

--- a/spec/core/config_mixin_spec.rb
+++ b/spec/core/config_mixin_spec.rb
@@ -1,5 +1,5 @@
+require "spec_helper"
 require "logstash/config/mixin"
-require "logstash/filters/base"
 
 describe LogStash::Config::Mixin do
   context "when validating :bytes successfully" do

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # config syntax tests
 #
-require "logstash/devutils/rspec/spec_helper"
+require "spec_helper"
 require "logstash/config/grammar"
 require "logstash/config/config_ast"
 require "logstash/errors"

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -4,7 +4,6 @@
 require "spec_helper"
 require "logstash/config/grammar"
 require "logstash/config/config_ast"
-require "logstash/errors"
 
 describe LogStashConfigParser do
   context '#parse' do

--- a/spec/core/event_spec.rb
+++ b/spec/core/event_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
-
 require "spec_helper"
-require "logstash/event"
 
 describe LogStash::Event do
   subject do

--- a/spec/core/event_spec.rb
+++ b/spec/core/event_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require "spec_helper"
 require "logstash/event"
 
 describe LogStash::Event do

--- a/spec/core/pipeline_spec.rb
+++ b/spec/core/pipeline_spec.rb
@@ -1,4 +1,4 @@
-require "logstash/devutils/rspec/spec_helper"
+require "spec_helper"
 
 class DummyInput < LogStash::Inputs::Base
   config_name "dummyinput"

--- a/spec/core/plugin_spec.rb
+++ b/spec/core/plugin_spec.rb
@@ -1,6 +1,5 @@
-require "logstash/namespace"
+require "spec_helper"
 require "logstash/plugin"
-require "logstash/filters/base"
 
 describe LogStash::Plugin do
   it "should fail lookup on inexisting type" do

--- a/spec/core/runner_spec.rb
+++ b/spec/core/runner_spec.rb
@@ -1,3 +1,4 @@
+require "spec_helper"
 require "logstash/runner"
 require "logstash/agent"
 require "logstash/kibana"

--- a/spec/core/runner_spec.rb
+++ b/spec/core/runner_spec.rb
@@ -1,6 +1,5 @@
 require "spec_helper"
 require "logstash/runner"
-require "logstash/agent"
 require "logstash/kibana"
 require "stud/task"
 

--- a/spec/core/timestamp_spec.rb
+++ b/spec/core/timestamp_spec.rb
@@ -1,4 +1,4 @@
-require "logstash/devutils/rspec/spec_helper"
+require "spec_helper"
 require "logstash/timestamp"
 
 describe LogStash::Timestamp do

--- a/spec/core/web_spec.rb
+++ b/spec/core/web_spec.rb
@@ -1,3 +1,5 @@
+require "spec_helper"
+
 describe "web tests" do
   context "rack rubygem" do
     it "must be available" do

--- a/spec/filters/base_spec.rb
+++ b/spec/filters/base_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
-require "logstash/devutils/rspec/spec_helper"
-require "logstash/filters/base"
-require "logstash/namespace"
+require "spec_helper"
 
 # use a dummy NOOP filter to test Filters::Base
 class LogStash::Filters::NOOP < LogStash::Filters::Base

--- a/spec/inputs/base_spec.rb
+++ b/spec/inputs/base_spec.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require "logstash/devutils/rspec/spec_helper"
+require "spec_helper"
 
 describe "LogStash::Inputs::Base#fix_streaming_codecs" do
   it "should carry the charset setting along when switching" do

--- a/spec/outputs/base_spec.rb
+++ b/spec/outputs/base_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
-require "logstash/devutils/rspec/spec_helper"
-require "logstash/outputs/base"
-require "logstash/namespace"
+require "spec_helper"
 
 # use a dummy NOOP output to test Outputs::Base
 class LogStash::Outputs::NOOP < LogStash::Outputs::Base

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,1 @@
 require "logstash/devutils/rspec/spec_helper"
-require 'logstash/devutils/rspec/logstash_helpers'
-
-require "logstash/filters/base"
-require "logstash/outputs/base"
-require "logstash/namespace"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require "logstash/devutils/rspec/spec_helper"
+require 'logstash/devutils/rspec/logstash_helpers'
+
+require "logstash/filters/base"
+require "logstash/outputs/base"
+require "logstash/namespace"

--- a/spec/util/accessors_spec.rb
+++ b/spec/util/accessors_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
-
-require "logstash/devutils/rspec/spec_helper"
+require "spec_helper"
 require "logstash/util/accessors"
 
 describe LogStash::Util::Accessors, :if => true do

--- a/spec/util/charset_spec.rb
+++ b/spec/util/charset_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
-
-require "logstash/devutils/rspec/spec_helper"
+require "spec_helper"
 require "logstash/util/charset"
 
 describe LogStash::Util::Charset do

--- a/spec/util/environment_spec.rb
+++ b/spec/util/environment_spec.rb
@@ -1,3 +1,4 @@
+require "spec_helper"
 require "logstash/environment"
 
 describe LogStash::Environment do

--- a/spec/util/fieldeval_spec.rb
+++ b/spec/util/fieldeval_spec.rb
@@ -1,4 +1,4 @@
-require "logstash/devutils/rspec/spec_helper"
+require "spec_helper"
 require "logstash/util/fieldreference"
 
 describe LogStash::Util::FieldReference, :if => true do

--- a/spec/util/json_spec.rb
+++ b/spec/util/json_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/json"
 require "logstash/environment"
 require "logstash/util"

--- a/spec/util/plugin_version_spec.rb
+++ b/spec/util/plugin_version_spec.rb
@@ -1,6 +1,5 @@
 require "spec_helper"
 require "logstash/util/plugin_version"
-require "logstash/errors"
 
 describe LogStash::Util::PluginVersion do
   subject { LogStash::Util::PluginVersion }

--- a/spec/util/plugin_version_spec.rb
+++ b/spec/util/plugin_version_spec.rb
@@ -1,3 +1,4 @@
+require "spec_helper"
 require "logstash/util/plugin_version"
 require "logstash/errors"
 

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -1,5 +1,6 @@
-require "logstash/util"
+require 'spec_helper'
 
+require "logstash/util"
 
 describe LogStash::Util do
 

--- a/tools/Gemfile.plugins.test
+++ b/tools/Gemfile.plugins.test
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 
 gemspec :name => "logstash", :path => File.expand_path(File.join(File.dirname(__FILE__), ".."))
 
+##
+# Install a set of plugins that are necessary for testing purpouses.
+##
+
 plugins = [ 'logstash-filter-clone',
             'logstash-filter-mutate',
             'logstash-input-generator',
@@ -14,3 +18,10 @@ plugins = [ 'logstash-filter-clone',
 plugins.each do |plugin|
   gem plugin
 end
+
+##
+# Dependencies related with coverage analysis
+##
+
+gem 'simplecov'
+gem 'coveralls'


### PR DESCRIPTION
The motivation of this PR is basically to enable the opportunity to get a coverage report from Logstash. This basically enable developers to get a coverage report when the ENV variable COVERAGE evaluate to true, so for example:

```COVERAGE=true ./bin/logstash rspec``` or ```COVERAGE=true rake test``` will create a coverage report.

If within a CI, Coveralls will get the report, fixing #2113.

### Note

coverage related gems are only installed when the user execute ```rake test:prep``` also used to install plugins used while testing.
