### PR TITLE
Use the .info level when printing the version notice for the plugin

### DIFF
--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -220,12 +220,12 @@ module LogStash::Config::Mixin
 
         if plugin_version < PLUGIN_VERSION_1_0_0
           if plugin_version < PLUGIN_VERSION_0_9_0
-            @logger.warn(I18n.t("logstash.plugin.version.0-1-x", 
+            @logger.info(I18n.t("logstash.plugin.version.0-1-x", 
                                 :type => @plugin_type,
                                 :name => @config_name,
                                 :LOGSTASH_VERSION => LOGSTASH_VERSION))
           else
-            @logger.warn(I18n.t("logstash.plugin.version.0-9-x", 
+            @logger.info(I18n.t("logstash.plugin.version.0-9-x", 
                                 :type => @plugin_type,
                                 :name => @config_name,
                                 :LOGSTASH_VERSION => LOGSTASH_VERSION))

--- a/spec/core/plugin_spec.rb
+++ b/spec/core/plugin_spec.rb
@@ -43,7 +43,7 @@ describe LogStash::Plugin do
         .with(plugin_name)
         .and_return(double(:version => Gem::Version.new('1.0.0')))
 
-      expect_any_instance_of(Cabin::Channel).not_to receive(:warn)
+      expect_any_instance_of(Cabin::Channel).not_to receive(:info)
       subject.validate({})
     end
 
@@ -52,7 +52,7 @@ describe LogStash::Plugin do
         .with(plugin_name)
         .and_return(double(:version => Gem::Version.new('0.9.1')))
 
-      expect_any_instance_of(Cabin::Channel).to receive(:warn)
+      expect_any_instance_of(Cabin::Channel).to receive(:info)
         .with(/Using version 0.9.x/)
 
       subject.validate({})
@@ -63,7 +63,7 @@ describe LogStash::Plugin do
         .with(plugin_name)
         .and_return(double(:version => Gem::Version.new('0.1.1')))
 
-      expect_any_instance_of(Cabin::Channel).to receive(:warn)
+      expect_any_instance_of(Cabin::Channel).to receive(:info)
         .with(/Using version 0.1.x/)
       subject.validate({})
     end
@@ -77,7 +77,7 @@ describe LogStash::Plugin do
         .with(plugin_name)
         .and_return(double(:version => Gem::Version.new('0.1.1')))
 
-      expect_any_instance_of(Cabin::Channel).to receive(:warn)
+      expect_any_instance_of(Cabin::Channel).to receive(:info)
         .once
         .with(/Using version 0.1.x/)
 


### PR DESCRIPTION
Fixes: https://github.com/elasticsearch/logstash/issues/1570