### PR TITLE
When sucessfully loading a plugin display a message in the current tty

### DIFF
--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -104,6 +104,7 @@ module LogStash::Config::Mixin
         I18n.t("logstash.agent.configuration.invalid_plugin_settings")
     end
 
+
     # set instance variables like '@foo'  for each config value given.
     params.each do |key, value|
       next if key[0, 1] == "@"
@@ -112,6 +113,10 @@ module LogStash::Config::Mixin
       @logger.debug("config #{self.class.name}/@#{key} = #{value.inspect}")
       instance_variable_set("@#{key}", value)
     end
+
+    @logger.terminal(I18n.t("logstash.plugin.activated_sucessfully", 
+                           :name => @plugin_type,
+                           :type => @plugin_type))
 
     @config = params
   end # def config_init

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -41,6 +41,8 @@ en:
       no_version: >-
         %{name} plugin doesn't have a version. This plugin isn't well
          supported by the community and likely has no maintainer.
+      activated_sucessfully: >-
+        %{name} %{type} plugin activated successfully.
       version:
         0-9-x:
          Using version 0.9.x %{type} plugin '%{name}'. This plugin should work but

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = LOGSTASH_VERSION
 
   # Core dependencies
-  gem.add_runtime_dependency "cabin", [">=0.6.0"]    #(Apache 2.0 license)
+  gem.add_runtime_dependency "cabin", [">=0.7.0"]    #(Apache 2.0 license)
   gem.add_runtime_dependency "pry"                   #(Ruby license)
   gem.add_runtime_dependency "stud"                  #(Apache 2.0 license)
   gem.add_runtime_dependency "clamp"                 #(MIT license) for command line args/flags


### PR DESCRIPTION
This fix will add a terminal message when logstash successfully load a plugin.
I've added this since the `version/milestone` message log level switched from `warn` to `info` and will only be show if we start logstash in --verbose.

```
File input plugin activated successfully.
```
related to https://github.com/elasticsearch/logstash/issues/1570