### PR TITLE
update jar_dependencies

### DIFF
--- a/lib/logstash/pluginmanager/util.rb
+++ b/lib/logstash/pluginmanager/util.rb
@@ -50,3 +50,15 @@ class LogStash::PluginManager::Util
   end
 
 end
+
+# This adds the "repo" element to the jar-dependencies DSL
+# allowing a gemspec to require a jar that exists in a custom
+# maven repository
+# Example:
+#   gemspec.requirements << "repo http://localhosty/repo"
+require 'maven/tools/dsl/project_gemspec'
+class Maven::Tools::DSL::ProjectGemspec
+  def repo(url)
+    @parent.repository(:id => url, :url => url)
+  end
+end

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |gem|
   # jar-dependencies 0.1.2 is included in jruby 1.7.6 no need to include here and
   # this avoids the gemspec jar path parsing issue of jar-dependencies 0.1.2
   #
-  gem.add_runtime_dependency "jar-dependencies", ["= 0.1.2"]   #(MIT license)
+  gem.add_runtime_dependency "jar-dependencies", ["= 0.1.7"]   #(MIT license)
 
   gem.add_runtime_dependency "ruby-maven"                       #(EPL license)
   gem.add_runtime_dependency "maven-tools"

--- a/tools/Gemfile.jruby-1.9.lock
+++ b/tools/Gemfile.jruby-1.9.lock
@@ -9,7 +9,7 @@ PATH
       filesize
       ftw (~> 0.0.40)
       i18n (= 0.6.9)
-      jar-dependencies (= 0.1.2)
+      jar-dependencies (= 0.1.7)
       jrjackson
       jruby-httpclient
       logstash-devutils
@@ -59,7 +59,7 @@ GEM
     i18n (0.6.9)
     ice_nine (0.11.1)
     insist (1.0.0)
-    jar-dependencies (0.1.2)
+    jar-dependencies (0.1.7)
     jrjackson (0.2.8)
     jruby-httpclient (1.1.1-java)
     logstash-devutils (0.0.7-java)

--- a/tools/Gemfile.plugins.test.jruby-1.9.lock
+++ b/tools/Gemfile.plugins.test.jruby-1.9.lock
@@ -9,7 +9,7 @@ PATH
       filesize
       ftw (~> 0.0.40)
       i18n (= 0.6.9)
-      jar-dependencies (= 0.1.2)
+      jar-dependencies (= 0.1.7)
       jrjackson
       jruby-httpclient
       logstash-devutils
@@ -59,7 +59,7 @@ GEM
     i18n (0.6.9)
     ice_nine (0.11.1)
     insist (1.0.0)
-    jar-dependencies (0.1.2)
+    jar-dependencies (0.1.7)
     jls-grok (0.11.0)
       cabin (>= 0.6.0)
     jrjackson (0.2.8)


### PR DESCRIPTION
update jar dependencies to 0.1.7 and added a DSL element to jar-dependencies language to allow using a custom maven repository in plugin jar dependencies