### PR TITLE
Delete the zipfile before building it.

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -85,6 +85,7 @@ namespace "artifact" do
     Rake::Task["dependency:rubyzip"].invoke
     require 'zip'
     zippath = "build/logstash-#{LOGSTASH_VERSION}.zip"
+    File.unlink(zippath) if File.exists?(zippath)
     Zip::File.open(zippath, Zip::File::CREATE) do |zipfile|
       files.each do |path|
         path_in_zip = "logstash-#{LOGSTASH_VERSION}/#{path}"


### PR DESCRIPTION
If we don't' do this, Zip::File.new and despite the Zip::File::CREATE
flag, will reopen an existing zip file instead of writing a new one.

The error you get without this patch is

    rake aborted!
    add failed. Entry logstash-2.0.0.dev/LICENSE already exists
    /Users/jls/projects/logstash/vendor/bundle/jruby/1.9/gems/rubyzip-1.1.6/lib/zip/file.rb:392:in
    `check_entry_exists'