### PR TITLE
fix encoding issue on windows+jruby

### DIFF
--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -117,6 +117,10 @@ module LogStash
       @jruby ||= !!(RUBY_PLATFORM == "java")
     end
 
+    def windows?
+      Gem.win_platform?
+    end
+
     def vendor_path(path)
       return ::File.join(LOGSTASH_HOME, "vendor", path)
     end

--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -296,7 +296,6 @@ class LogStash::Event
   def self.validate_value(value)
     case value
     when String
-      value.force_encoding("UTF-8") if LogStash::Environment.windows?
       raise("expected UTF-8 encoding for value=#{value}, encoding=#{value.encoding.inspect}") unless value.encoding == Encoding::UTF_8
       raise("invalid UTF-8 encoding for value=#{value}, encoding=#{value.encoding.inspect}") unless value.valid_encoding?
       value

--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -296,6 +296,7 @@ class LogStash::Event
   def self.validate_value(value)
     case value
     when String
+      value.force_encoding("UTF-8") if LogStash::Environment.windows?
       raise("expected UTF-8 encoding for value=#{value}, encoding=#{value.encoding.inspect}") unless value.encoding == Encoding::UTF_8
       raise("invalid UTF-8 encoding for value=#{value}, encoding=#{value.encoding.inspect}") unless value.valid_encoding?
       value

--- a/lib/logstash/monkeypatches-for-bugs.rb
+++ b/lib/logstash/monkeypatches-for-bugs.rb
@@ -1,0 +1,34 @@
+require "logstash/environment"
+
+if LogStash::Environment.windows? && LogStash::Environment.jruby? then
+  require "socket"
+  module JRubyBug2558SocketPeerAddrBugFix
+    def peeraddr
+      orig_peeraddr.map do |v|
+        case v
+        when String
+          v.force_encoding(Encoding::UTF_8)
+        else
+          v
+        end
+      end
+    end
+  end
+
+  class << Socket
+    # Bugfix for jruby #2558
+    alias_method :orig_gethostname, :gethostname
+    def gethostname
+      return orig_gethostname.force_encoding(Encoding::UTF_8)
+    end
+  end
+
+  class TCPSocket
+    alias_method :orig_peeraddr, :peeraddr
+    include JRubyBug2558SocketPeerAddrBugFix
+  end
+  class UDPSocket
+    alias_method :orig_peeraddr, :peeraddr
+    include JRubyBug2558SocketPeerAddrBugFix
+  end
+end

--- a/lib/logstash/runner.rb
+++ b/lib/logstash/runner.rb
@@ -45,6 +45,7 @@ if ENV["PROFILE_BAD_LOG_CALLS"] || $DEBUGLIST.include?("log")
   end
 end # PROFILE_BAD_LOG_CALLS
 
+require "logstash/monkeypatches-for-bugs"
 require "logstash/monkeypatches-for-debugging"
 require "logstash/namespace"
 require "logstash/program"


### PR DESCRIPTION
When getting data from the socket stdlib (either through Socket.gethostname, socket.peeraddr[3], or others) windows will produce a string with Windows-1525 encoding.
When a plugin tries to do `event[field] = string`, Event.validate_value will raise exception since the string isn't UTF-8 encoded.

This is a temporary fix until JRuby fixes https://github.com/jruby/jruby/issues/2558

fixes (at least): https://github.com/logstash-plugins/logstash-input-tcp/issues/2 https://github.com/logstash-plugins/logstash-input-syslog/issues/4 https://github.com/logstash-plugins/logstash-input-pipe/issues/3 https://github.com/logstash-plugins/logstash-input-generator/issues/4 https://github.com/logstash-plugins/logstash-input-file/issues/9 https://github.com/logstash-plugins/logstash-filter-metrics/issues/6 