### PR TITLE
Update to documentation templates

### DIFF
--- a/docs/plugin-doc.asciidoc.erb
+++ b/docs/plugin-doc.asciidoc.erb
@@ -8,9 +8,15 @@
 
 ==== Synopsis
 
+<% if sorted_attributes.count > 0 -%>
 This plugin supports the following configuration options:
+<% else -%>
+This plugin has no configuration options.
+<% end -%>
 
 <%= synopsis -%>
+
+<% if sorted_attributes.count > 0 -%>
 
 ==== Details
 
@@ -51,5 +57,7 @@ This plugin supports the following configuration options:
 <% end -%>
 
 <%= config[:description] %>
+
+<% end -%>
 
 <% end -%>

--- a/docs/plugin-synopsis.asciidoc.erb
+++ b/docs/plugin-synopsis.asciidoc.erb
@@ -1,6 +1,10 @@
 <%- plugin_name = name -%>
 
+<% if sorted_attributes.count > 0 -%>
 Required configuration options:
+<% else -%>
+Complete configuration example:
+<% end -%>
 
 [source,json]
 --------------------------
@@ -9,7 +13,7 @@ Required configuration options:
    next if config[:deprecated]
    next if !config[:required]
 -%>
-<%= "  " if section == "codec" %>    <%= name %> => ... 
+<%= "  " if section == "codec" %>    <%= name %> => ...
 <% end -%>
 <%= "  " if section == "codec" %>}
 --------------------------
@@ -23,7 +27,7 @@ Available configuration options:
 |Setting |Input type|Required|Default value
 <% sorted_attributes.each do |name, config|
    next if config[:deprecated]
-   if config[:validate].is_a?(Array) 
+   if config[:validate].is_a?(Array)
      annotation = "|<<string,string>>, one of `#{config[:validate].inspect}`"
    elsif config[:validate] == :path
      annotation = "|a valid filesystem path"
@@ -41,7 +45,7 @@ Available configuration options:
    end
    if config.include?(:default)
      annotation += "|`#{config[:default].inspect}`"
-   else 
+   else
      annotation += "|"
    end
 -%>

--- a/docs/plugin-synopsis.asciidoc.erb
+++ b/docs/plugin-synopsis.asciidoc.erb
@@ -9,13 +9,14 @@ Complete configuration example:
 [source,json]
 --------------------------
 <%= name %> {
+<% if sorted_attributes.count > 0 -%>
 <% sorted_attributes.each do |name, config|
    next if config[:deprecated]
    next if !config[:required]
 -%>
 <%= "  " if section == "codec" %>    <%= name %> => ...
 <% end -%>
-<%= "  " if section == "codec" %>}
+<%= "  " if section == "codec" %><% ; end -%>}
 --------------------------
 
 <% if sorted_attributes.count > 0 %>


### PR DESCRIPTION
This update presents alternate text if no configuration options
exist for a plugin.

It even hides the Details section if there are no configuration
parameters.