### PR TITLE
Add asciidoc NOTE: for community-supported plugins

### DIFF
--- a/docs/asciidoc/static/configuration.asciidoc
+++ b/docs/asciidoc/static/configuration.asciidoc
@@ -240,6 +240,7 @@ input { # comments can appear at the end of a line, too
 }
 ----------------------------------
 
+[[logstash-config-field-references]]
 [float]
 === Field References
 

--- a/docs/asciidocgen.rb
+++ b/docs/asciidocgen.rb
@@ -32,6 +32,14 @@ class LogStashConfigAsciiDocGenerator
     else
       @contrib_list = []
     end
+
+    if File.exists?("rakelib/default_plugins.rb")
+      # list of supported / shipped with Logstash plugins
+      @supported_plugins = eval(File.read("rakelib/default_plugins.rb"))
+    else
+      # we support nothing???
+      @supported_plugins = []
+    end
   end
 
   def parse(string)
@@ -206,6 +214,9 @@ class LogStashConfigAsciiDocGenerator
     elsif klass.ancestors.include?(LogStash::Codecs::Base)
       section = "codec"
     end
+
+    plugin_name = "logstash-" + section + "-" + @name
+    default_plugin = @supported_plugins.include?(plugin_name)
 
     template_file = File.join(File.dirname(__FILE__), "plugin-doc.asciidoc.erb")
     template = ERB.new(File.new(template_file).read, nil, "-")

--- a/docs/plugin-doc.asciidoc.erb
+++ b/docs/plugin-doc.asciidoc.erb
@@ -3,7 +3,7 @@
 === <%= name %>
 
 <% unless default_plugin %>
-NOTE: This is a community-contributed plugin! It does not ship with logstash by default, but it is easy to install! To use this, you must have installed the contrib plugins package.
+    +NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/plugin install logstash-<%= section %>-<%= plugin_name %>`.
 <% end %>
 
 <%= description %>

--- a/docs/plugin-doc.asciidoc.erb
+++ b/docs/plugin-doc.asciidoc.erb
@@ -2,6 +2,10 @@
 [[plugins-<%= section %>s-<%= name %>]]
 === <%= name %>
 
+<% unless default_plugin %>
+NOTE: This is a community-contributed plugin! It does not ship with logstash by default, but it is easy to install! To use this, you must have installed the contrib plugins package.
+<% end %>
+
 <%= description %>
 
 &nbsp;


### PR DESCRIPTION
This should read the list of Logstash-shipped plugins from the default_plugins.rb file and add an asciidoc NOTE: Admonition to signify that it is community-supported.