### PR TITLE
ungz was named incorrectly

### DIFF
--- a/lib/logstash/util/filetools.rb
+++ b/lib/logstash/util/filetools.rb
@@ -177,7 +177,7 @@ module LogStash::Util::FileTools
         end
 
       elsif download =~ /.gz/
-        ungz(download)
+        do_ungz(download)
       end
     end
   end


### PR DESCRIPTION
If your `vendor.json` specifies a file that is just gzipped (such as `lcg.json.gz`) then the file cannot be extracted properly because the function is misnamed.

Example error: https://gist.github.com/tebriel/f8a15eb5e1250249b2ea