### PR TITLE
logstash-core gem 

### DIFF
--- a/logstash-core.gemspec
+++ b/logstash-core.gemspec
@@ -1,0 +1,85 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/logstash/version', __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.authors       = ["Jordan Sissel", "Pete Fritchman", "Elasticsearch"]
+  gem.email         = ["jls@semicomplete.com", "petef@databits.net", "info@elasticsearch.com"]
+  gem.description   = %q{The core components of logstash, the scalable log and event management tool}
+  gem.summary       = %q{logstash-core - The core components of logstash}
+  gem.homepage      = "http://logstash.net/"
+  gem.license       = "Apache License (2.0)"
+
+  gem.files         = Dir.glob(["lib/**/*.rb", "locales/*"])
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.name          = "logstash-core"
+  gem.require_paths = ["lib"]
+  gem.version       = LOGSTASH_VERSION
+
+  # Core dependencies
+  gem.add_runtime_dependency "cabin", [">=0.7.0"]    #(Apache 2.0 license)
+  gem.add_runtime_dependency "pry"                   #(Ruby license)
+  gem.add_runtime_dependency "stud"                  #(Apache 2.0 license)
+  gem.add_runtime_dependency "clamp"                 #(MIT license) for command line args/flags
+  gem.add_runtime_dependency "filesize"              #(MIT license) for :bytes config validator
+
+  # TODO(sissel): Treetop 1.5.x doesn't seem to work well, but I haven't
+  # investigated what the cause might be. -Jordan
+  gem.add_runtime_dependency "treetop", ["~> 1.4.0"] #(MIT license)
+
+  # upgrade i18n only post 0.6.11, see https://github.com/svenfuchs/i18n/issues/270
+  gem.add_runtime_dependency "i18n", ["=0.6.9"]   #(MIT license)
+
+  # Web dependencies
+  gem.add_runtime_dependency "ftw", ["~> 0.0.40"] #(Apache 2.0 license)
+  gem.add_runtime_dependency "mime-types"         #(GPL 2.0)
+  gem.add_runtime_dependency "rack"               #(MIT-style license)
+  gem.add_runtime_dependency "sinatra"            #(MIT-style license)
+
+  # Plugin manager dependencies
+
+  # Currently there is a blocking issue with the latest (3.1.1.0.9) version of
+  # `ruby-maven` # and installing jars dependencies. If you are declaring a gem
+  # in a gemfile # using the :github option it will make the bundle install crash,
+  # before upgrading this gem you need to test the version with any plugins
+  # that require jars.
+  #
+  # Ticket: https://github.com/elasticsearch/logstash/issues/2595
+  gem.add_runtime_dependency "jar-dependencies", '0.1.7'   #(MIT license)
+  gem.add_runtime_dependency "ruby-maven", '3.1.1.0.8'                       #(EPL license)
+  gem.add_runtime_dependency "maven-tools", '1.0.7'
+
+  gem.add_runtime_dependency "minitar"
+  gem.add_runtime_dependency "file-dependencies", '0.1.6'
+
+  if RUBY_PLATFORM == 'java'
+    gem.platform = RUBY_PLATFORM
+
+    # bouncy-castle-java 1.5.0147 and jruby-openssl 0.9.5 are included in jruby 1.7.6 no need to include here
+    # and this avoids the gemspec jar path parsing issue of jar-dependencies 0.1.2
+    gem.add_runtime_dependency "jruby-httpclient"                    #(Apache 2.0 license)
+    gem.add_runtime_dependency "jrjackson"                           #(Apache 2.0 license)
+  else
+    gem.add_runtime_dependency "excon"    #(MIT license)
+    gem.add_runtime_dependency "oj"       #(MIT-style license)
+  end
+
+  if RUBY_ENGINE == "rbx"
+    # rubinius puts the ruby stdlib into gems.
+    gem.add_runtime_dependency "rubysl"
+
+    # Include racc to make the xml tests pass.
+    # https://github.com/rubinius/rubinius/issues/2632#issuecomment-26954565
+    gem.add_runtime_dependency "racc"
+  end
+
+  # These are runtime-deps so you can do 'java -jar logstash.jar rspec <test>'
+  gem.add_development_dependency "rspec", "~> 2.14.0" #(MIT license)
+
+  gem.add_development_dependency "logstash-devutils"
+
+  # Testing dependencies
+  gem.add_development_dependency "ci_reporter", "1.9.3"
+  gem.add_development_dependency "simplecov"
+  gem.add_development_dependency "coveralls"
+
+end

--- a/logstash-core.gemspec
+++ b/logstash-core.gemspec
@@ -81,5 +81,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "ci_reporter", "1.9.3"
   gem.add_development_dependency "simplecov"
   gem.add_development_dependency "coveralls"
-
 end

--- a/logstash.gemspec
+++ b/logstash.gemspec
@@ -2,84 +2,16 @@
 require File.expand_path('../lib/logstash/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Jordan Sissel", "Pete Fritchman"]
-  gem.email         = ["jls@semicomplete.com", "petef@databits.net"]
-  gem.description   = %q{scalable log and event management (search, archive, pipeline)}
-  gem.summary       = %q{logstash - log and event management}
+  gem.authors       = ["Jordan Sissel", "Pete Fritchman", "Elasticsearch"]
+  gem.email         = ["jls@semicomplete.com", "petef@databits.net", "info@elasticsearch.com"]
+  gem.description   = %q{The core components of logstash, the scalable log and event management tool}
+  gem.summary       = %q{logstash-core - The core components of logstash}
   gem.homepage      = "http://logstash.net/"
   gem.license       = "Apache License (2.0)"
 
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = Dir.glob("lib/**/*.rb")
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "logstash"
   gem.require_paths = ["lib"]
   gem.version       = LOGSTASH_VERSION
-
-  # Core dependencies
-  gem.add_runtime_dependency "cabin", [">=0.7.0"]    #(Apache 2.0 license)
-  gem.add_runtime_dependency "pry"                   #(Ruby license)
-  gem.add_runtime_dependency "stud"                  #(Apache 2.0 license)
-  gem.add_runtime_dependency "clamp"                 #(MIT license) for command line args/flags
-  gem.add_runtime_dependency "filesize"              #(MIT license) for :bytes config validator
-
-  # TODO(sissel): Treetop 1.5.x doesn't seem to work well, but I haven't
-  # investigated what the cause might be. -Jordan
-  gem.add_runtime_dependency "treetop", ["~> 1.4.0"] #(MIT license)
-
-  # upgrade i18n only post 0.6.11, see https://github.com/svenfuchs/i18n/issues/270
-  gem.add_runtime_dependency "i18n", ["=0.6.9"]   #(MIT license)
-
-  # Web dependencies
-  gem.add_runtime_dependency "ftw", ["~> 0.0.40"] #(Apache 2.0 license)
-  gem.add_runtime_dependency "mime-types"         #(GPL 2.0)
-  gem.add_runtime_dependency "rack"               #(MIT-style license)
-  gem.add_runtime_dependency "sinatra"            #(MIT-style license)
-
-  # Plugin manager dependencies
-
-  # Currently there is a blocking issue with the latest (3.1.1.0.9) version of
-  # `ruby-maven` # and installing jars dependencies. If you are declaring a gem
-  # in a gemfile # using the :github option it will make the bundle install crash,
-  # before upgrading this gem you need to test the version with any plugins
-  # that require jars.
-  #
-  # Ticket: https://github.com/elasticsearch/logstash/issues/2595
-  gem.add_runtime_dependency "jar-dependencies", '0.1.7'   #(MIT license)
-  gem.add_runtime_dependency "ruby-maven", '3.1.1.0.8'                       #(EPL license)
-  gem.add_runtime_dependency "maven-tools", '1.0.7'
-
-  gem.add_runtime_dependency "minitar"
-  gem.add_runtime_dependency "file-dependencies", '0.1.6'
-
-  if RUBY_PLATFORM == 'java'
-    gem.platform = RUBY_PLATFORM
-
-    # bouncy-castle-java 1.5.0147 and jruby-openssl 0.9.5 are included in jruby 1.7.6 no need to include here
-    # and this avoids the gemspec jar path parsing issue of jar-dependencies 0.1.2
-    gem.add_runtime_dependency "jruby-httpclient"                    #(Apache 2.0 license)
-    gem.add_runtime_dependency "jrjackson"                           #(Apache 2.0 license)
-  else
-    gem.add_runtime_dependency "excon"    #(MIT license)
-    gem.add_runtime_dependency "oj"       #(MIT-style license)
-  end
-
-  if RUBY_ENGINE == "rbx"
-    # rubinius puts the ruby stdlib into gems.
-    gem.add_runtime_dependency "rubysl"
-
-    # Include racc to make the xml tests pass.
-    # https://github.com/rubinius/rubinius/issues/2632#issuecomment-26954565
-    gem.add_runtime_dependency "racc"
-  end
-
-  # These are runtime-deps so you can do 'java -jar logstash.jar rspec <test>'
-  gem.add_development_dependency "rspec", "~> 2.14.0" #(MIT license)
-
-  gem.add_development_dependency "logstash-devutils"
-
-  # Testing dependencies
-  gem.add_development_dependency "ci_reporter", "1.9.3"
-  gem.add_development_dependency "simplecov"
-  gem.add_development_dependency "coveralls"
-
 end

--- a/tools/Gemfile
+++ b/tools/Gemfile
@@ -1,0 +1,8 @@
+source "http://rubygems.org"
+
+gemspec :path => File.expand_path(File.join(File.dirname(__FILE__), "..")), :name => "logstash", :development_group => :development
+gemspec :path => File.expand_path(File.join(File.dirname(__FILE__), "..")), :name => "logstash-core", :development_group => :development
+
+# in development if a local, unpublished gems is required, you must add it first in the gemspec without the :path option
+# and also add it here with the :path option.
+

--- a/tools/Gemfile.jruby-1.9.lock
+++ b/tools/Gemfile.jruby-1.9.lock
@@ -1,0 +1,123 @@
+PATH
+  remote: /Users/ph/es/logstash
+  specs:
+    logstash (2.0.0.dev)
+      ci_reporter (= 1.9.3)
+    logstash-core (2.0.0.dev-java)
+      cabin (>= 0.7.0)
+      clamp (~> 0)
+      file-dependencies (~> 0)
+      filesize (~> 0)
+      ftw (~> 0.0.40)
+      i18n (= 0.6.9)
+      jar-dependencies (= 0.1.7)
+      jrjackson (~> 0)
+      jruby-httpclient (~> 0)
+      logstash-devutils (~> 0)
+      maven-tools (= 1.0.7)
+      mime-types
+      minitar (~> 0)
+      pry (~> 0)
+      rack
+      rspec (~> 2.14.0)
+      ruby-maven (= 3.1.1.0.8)
+      sinatra
+      stud (~> 0)
+      treetop (~> 1.4.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.7)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
+    backports (3.6.4)
+    builder (3.2.2)
+    cabin (0.7.1)
+    ci_reporter (1.9.3)
+      builder (>= 2.1.2)
+    clamp (0.6.3)
+    coderay (1.1.0)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    diff-lcs (1.2.5)
+    equalizer (0.0.9)
+    ffi (1.9.6-java)
+    file-dependencies (0.1.4)
+      minitar
+    filesize (0.0.4)
+    ftw (0.0.42)
+      addressable
+      backports (>= 2.6.2)
+      cabin (> 0)
+      http_parser.rb (~> 0.6)
+    gem_publisher (1.5.0)
+    http_parser.rb (0.6.0-java)
+    i18n (0.6.9)
+    ice_nine (0.11.1)
+    insist (1.0.0)
+    jar-dependencies (0.1.7)
+    jrjackson (0.2.8)
+    jruby-httpclient (0.4.0-java)
+    logstash-devutils (0.0.8-java)
+      gem_publisher
+      insist (= 1.0.0)
+      jar-dependencies
+      minitar
+      rake
+    maven-tools (1.0.7)
+      virtus (~> 1.0)
+    method_source (0.8.2)
+    mime-types (2.4.3)
+    minitar (0.5.4)
+    polyglot (0.3.5)
+    pry (0.10.1-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    rake (10.4.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+    ruby-maven (3.1.1.0.8)
+      maven-tools (~> 1.0.1)
+      ruby-maven-libs (= 3.1.1)
+    ruby-maven-libs (3.1.1)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    slop (3.6.0)
+    spoon (0.0.4)
+      ffi
+    stud (0.0.19)
+    thread_safe (0.3.4-java)
+    tilt (1.4.1)
+    treetop (1.4.15)
+      polyglot
+      polyglot (>= 0.3.1)
+      virtus (1.0.4)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  logstash!
+  logstash-core!

--- a/tools/Gemfile.plugins
+++ b/tools/Gemfile.plugins
@@ -1,0 +1,7 @@
+require 'rakelib/default_plugins'
+
+source 'https://rubygems.org'
+
+gemspec :name => "logstash-core", :path => File.expand_path(File.join(File.dirname(__FILE__), ".."))
+
+DEFAULT_PLUGINS.each {|p| gem p}

--- a/tools/Gemfile.plugins.all
+++ b/tools/Gemfile.plugins.all
@@ -1,0 +1,14 @@
+require 'octokit'
+skiplist = Regexp.union([ /^logstash-codec-cef$/, /^logstash-input-gemfire$/, /^logstash-output-gemfire$/, /^logstash-filter-metricize$/, /^logstash-filter-yaml$/, /jms$/, /example$/])
+
+source 'https://rubygems.org'
+
+gemspec :name => "logstash", :path => ".."
+gemspec :name => "logstash-core", :path => ".."
+
+Octokit.auto_paginate = true
+repo_list = Octokit.organization_repositories("logstash-plugins")
+repo_list.each do |repo|
+  next if repo.name =~ skiplist
+  gem repo.name
+end

--- a/tools/Gemfile.plugins.test
+++ b/tools/Gemfile.plugins.test
@@ -1,0 +1,28 @@
+require 'rakelib/default_plugins'
+
+source 'https://rubygems.org'
+
+gemspec :name => "logstash", :path => File.expand_path(File.join(File.dirname(__FILE__), ".."))
+gemspec :name => "logstash-core", :path => File.expand_path(File.join(File.dirname(__FILE__), ".."))
+
+##
+# Install a set of plugins that are necessary for testing purpouses.
+##
+
+plugins = [ 'logstash-filter-clone',
+            'logstash-filter-mutate',
+            'logstash-input-generator',
+            'logstash-input-stdin',
+            'logstash-input-tcp',
+            'logstash-output-stdout']
+
+plugins.each do |plugin|
+  gem plugin
+end
+
+##
+# Dependencies related with coverage analysis
+##
+
+gem 'simplecov'
+gem 'coveralls'

--- a/tools/Gemfile.plugins.test.jruby-1.9.lock
+++ b/tools/Gemfile.plugins.test.jruby-1.9.lock
@@ -1,0 +1,193 @@
+PATH
+  remote: /Users/ph/es/logstash
+  specs:
+    logstash (2.0.0.dev)
+      ci_reporter (= 1.9.3)
+    logstash-core (2.0.0.dev-java)
+      cabin (>= 0.7.0)
+      clamp (~> 0)
+      file-dependencies (~> 0)
+      filesize (~> 0)
+      ftw (~> 0.0.40)
+      i18n (= 0.6.9)
+      jar-dependencies (= 0.1.7)
+      jrjackson (~> 0)
+      jruby-httpclient (~> 0)
+      logstash-devutils (~> 0)
+      maven-tools (= 1.0.7)
+      mime-types
+      minitar (~> 0)
+      pry (~> 0)
+      rack
+      rspec (~> 2.14.0)
+      ruby-maven (= 3.1.1.0.8)
+      sinatra
+      stud (~> 0)
+      treetop (~> 1.4.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.7)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
+    backports (3.6.4)
+    builder (3.2.2)
+    cabin (0.7.1)
+    ci_reporter (1.9.3)
+      builder (>= 2.1.2)
+    clamp (0.6.3)
+    coderay (1.1.0)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
+    coveralls (0.7.9)
+      multi_json (~> 1.10)
+      rest-client (~> 1.7)
+      simplecov (~> 0.9.1)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    equalizer (0.0.9)
+    ffi (1.9.6-java)
+    file-dependencies (0.1.4)
+      minitar
+    filesize (0.0.4)
+    ftw (0.0.42)
+      addressable
+      backports (>= 2.6.2)
+      cabin (> 0)
+      http_parser.rb (~> 0.6)
+    gem_publisher (1.5.0)
+    http_parser.rb (0.6.0-java)
+    i18n (0.6.9)
+    ice_nine (0.11.1)
+    insist (1.0.0)
+    jar-dependencies (0.1.7)
+    jls-grok (0.11.0)
+      cabin (>= 0.6.0)
+    jrjackson (0.2.8)
+    jruby-httpclient (0.4.0-java)
+    logstash-codec-json (0.1.5)
+      logstash (>= 1.4.0, < 2.0.0)
+    logstash-codec-json_lines (0.1.5)
+      logstash (>= 1.4.0, < 2.0.0)
+      logstash-codec-line
+    logstash-codec-line (0.1.3)
+      logstash (>= 1.4.0, < 2.0.0)
+    logstash-codec-plain (0.1.3)
+      logstash (>= 1.4.0, < 2.0.0)
+    logstash-devutils (0.0.8-java)
+      gem_publisher
+      insist (= 1.0.0)
+      jar-dependencies
+      minitar
+      rake
+    logstash-filter-clone (0.1.2)
+      logstash (>= 1.4.0, < 2.0.0)
+    logstash-filter-grok (0.1.2)
+      jls-grok (= 0.11.0)
+      logstash (>= 1.4.0, < 2.0.0)
+      logstash-patterns-core
+    logstash-filter-mutate (0.1.2)
+      logstash (>= 1.4.0, < 2.0.0)
+      logstash-filter-grok
+      logstash-patterns-core
+    logstash-input-generator (0.1.1)
+      logstash (>= 1.4.0, < 2.0.0)
+      logstash-codec-plain
+    logstash-input-stdin (0.1.1)
+      logstash (>= 1.4.0, < 2.0.0)
+      logstash-codec-json
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-codec-plain
+    logstash-input-tcp (0.1.1)
+      logstash (>= 1.4.0, < 2.0.0)
+      logstash-codec-json
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-codec-plain
+    logstash-output-stdout (0.1.2)
+      logstash (>= 1.4.0, < 2.0.0)
+      logstash-codec-line
+    logstash-patterns-core (0.1.4)
+      logstash (>= 1.4.0, < 2.0.0)
+    maven-tools (1.0.7)
+      virtus (~> 1.0)
+    method_source (0.8.2)
+    mime-types (2.4.3)
+    minitar (0.5.4)
+    multi_json (1.10.1)
+    netrc (0.10.2)
+    polyglot (0.3.5)
+    pry (0.10.1-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    rake (10.4.2)
+    rest-client (1.7.2)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+    ruby-maven (3.1.1.0.8)
+      maven-tools (~> 1.0.1)
+      ruby-maven-libs (= 3.1.1)
+    ruby-maven-libs (3.1.1)
+    simplecov (0.9.1)
+      docile (~> 1.1.0)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    slop (3.6.0)
+    spoon (0.0.4)
+      ffi
+    stud (0.0.19)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
+    thor (0.19.1)
+    thread_safe (0.3.4-java)
+    tilt (1.4.1)
+    tins (1.3.4)
+    treetop (1.4.15)
+      polyglot
+      polyglot (>= 0.3.1)
+    virtus (1.0.4)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  coveralls
+  logstash!
+  logstash-core!
+  logstash-filter-clone
+  logstash-filter-mutate
+  logstash-input-generator
+  logstash-input-stdin
+  logstash-input-tcp
+  logstash-output-stdout
+  simplecov


### PR DESCRIPTION
Add an option to generate a logstash-core gem, including some deduplication of dependencies so are most of them just loaded from the core.

Fixes #2474