### PR TITLE
Use shell scripts to setup in an easy way our CI jobs.

### DIFF
--- a/ci/ci_setup.sh
+++ b/ci/ci_setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+#squid proxy work, so if there is a proxy it can be cached.
+sed -i.bak 's/https:/http:/' tools/Gemfile
+
+# Clean up some  possible stale directories
+rm -rf vendor       # make sure there are no vendorized dependencies
+rm -rf spec/reports # no stale spec reports from previous executions
+
+# Setup the environment
+rake bootstrap # Bootstrap your logstash instance

--- a/ci/ci_test.sh
+++ b/ci/ci_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+##
+# Keep in mind to run ci/ci_setup.sh if you need to setup/clean up your environment before
+# running the test suites here.
+##
+
+SELECTED_TEST_SUITE=$1
+
+if [[ $SELECTED_TEST_SUITE == $"all" ]]; then
+  echo "Running all plugins tests"
+  rake plugin:install-all   # Install all plugins, using the file at tools/Gemfile.plugins.all
+  rake vendor:append_development_dependencies\[tools/Gemfile.plugins.all\] # Append development dependencies to run the test
+  rake plugin:install-all   # Install previously appended development dependencies
+
+  #Run the specs test from all previously installed logstash plugins
+  ./bin/logstash rspec --order rand vendor/bundle/jruby/1.9/gems/logstash-*/spec/{input,filter,codec,output}s/*_spec.rb
+else
+  echo "Running core tests"
+  rake test:prep # setup the necessary plugins and dependencies for testing
+  # Execute the test
+  ./bin/logstash rspec --order rand --format CI::Reporter::RSpec spec/**/*_spec.rb spec/*_spec.rb
+fi


### PR DESCRIPTION
I try in this change to wrap up some easy changes in the way we aim to run our CI jobs that will allow us to have:

* An easiest way for everyone, including Jenkins to run the different test jobs for logstash.
* Add a common, non changing, interface that developers and machines (aka Jenkins) could rely not to change.
* Have a way to document, in code, the necessary steps to setup and run the test suites for Logstash.

if we apply this change a sample Jenkins configuration could end up being as simple as:

```
#!/bin/bash

# Select and setup the local ruby environment if need.
# End of that the ruby setup.

export COVERALLS_REPO_TOKEN=....

ci/ci_setup.sh
COVERAGE=true ci/ci_test.sh
```

* ```ci_setup.sh```: takes care of setting up all the general environment to run the Logstash test.
* ```ci_test.sh```: takes care of runnig the test. This script accepts a parameter that setup and run core or all-plugins tests.

By doing this we could simplify the transition process for changes like #2634, as the naming changes would be scope under a common interface.