### PR TITLE
Use shell scripts to setup in an easy way our CI jobs.

### DIFF
--- a/ci/ci_setup.sh
+++ b/ci/ci_setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+##
+# Note this setup needs a system ruby to be available, this can not
+# be done here as is higly system dependant.
+##
+
+#squid proxy work, so if there is a proxy it can be cached.
+sed -i.bak 's/https:/http:/' Gemfile
+
+# Clean up some  possible stale directories
+rm -rf vendor       # make sure there are no vendorized dependencies
+rm -rf spec/reports # no stale spec reports from previous executions
+
+# Setup the environment
+rake bootstrap # Bootstrap your logstash instance

--- a/ci/ci_test.sh
+++ b/ci/ci_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+##
+# Keep in mind to run ci/ci_setup.sh if you need to setup/clean up your environment before
+# running the test suites here.
+##
+
+SELECTED_TEST_SUITE=$1
+
+if [[ $SELECTED_TEST_SUITE == $"core-fail-fast" ]]; then
+  echo "Running core-fail-fast tests"
+  rake test:install-core    # Install core dependencies for testing.
+  rake test:core-fail-fast  # Run core tests
+elif [[ $SELECTED_TEST_SUITE == $"all" ]]; then
+  echo "Running all plugins tests"
+  rake test:install-all     # Install all plugins in this logstash instance, including development dependencies
+  rake test:plugins         # Run all plugins tests
+else
+  echo "Running core tests"
+  rake test:install-core    # Install core dependencies for testing.
+  rake test:core            # Run core tests
+fi


### PR DESCRIPTION
This is basically doing the same as in #2639 but for the bundler-move branch, I copy here the description for the other PR so it stays as a reference.

----

I try in this change to wrap up some easy changes in the way we aim to run our CI jobs that will allow us to have:

* An easiest way for everyone, including Jenkins to run the different test jobs for logstash.
* Add a common, non changing, interface that developers and machines (aka Jenkins) could rely not to change.
* Have a way to document, in code, the necessary steps to setup and run the test suites for Logstash.

if we apply this change a sample Jenkins configuration could end up being as simple as:

```
#!/bin/bash

# Select and setup the local ruby environment if need.
# End of that the ruby setup.

export COVERALLS_REPO_TOKEN=....

ci/ci_setup.sh
COVERAGE=true ci/ci_test.sh
```

* ```ci_setup.sh```: takes care of setting up all the general environment to run the Logstash test.
* ```ci_test.sh```: takes care of runnig the test. This script accepts a parameter that setup and run core or all-plugins tests.

By doing this we could simplify the transition process for changes like #2634, as the naming changes would be scope under a common interface.

----