### PR TITLE
Two fixes for plugin manager

### DIFF
--- a/lib/logstash/pluginmanager/list.rb
+++ b/lib/logstash/pluginmanager/list.rb
@@ -34,5 +34,7 @@ class LogStash::PluginManager::List < Clamp::Command
       line += " (#{spec.version})" if verbose?
       puts(line)
     end
+
+    return 0
   end
 end # class Logstash::PluginManager

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -9,7 +9,6 @@ namespace "artifact" do
       "patterns/**/*",
       "vendor/??*/**/*",
       "Gemfile*",
-      ".bundle/*",
       "logstash.gemspec",
     ]
   end


### PR DESCRIPTION
fixes bin\plugin list on windows
fixes bin\plugin operations on a release

fixes #2641 