### PR TITLE
remove unnecessary .bundle directory from the artifact

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -9,7 +9,6 @@ namespace "artifact" do
       "patterns/**/*",
       "vendor/??*/**/*",
       "Gemfile*",
-      ".bundle/*",
       "logstash.gemspec",
     ]
   end


### PR DESCRIPTION
In a release, the .bundle/config has a BUNDLE_PATH setting that can interfere by misleading the plugin manager into not seeing the vendor/bundle path.