### PR TITLE
Fallback to a local configuration if the parsing for remote

### DIFF
--- a/spec/logstash/agent_spec.rb
+++ b/spec/logstash/agent_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe LogStash::Agent do
+  subject { LogStash::Agent.new('') }
+  let(:dummy_config) { 'input {}' }
+
+  context "when loading the configuration" do
+    context "when local" do
+      before { expect(subject).to receive(:local_config).with(path) }
+
+      context "unix" do
+        let(:path) { './test.conf' }
+        it 'works with relative path' do
+          subject.load_config(path)
+        end
+      end
+
+      context "windows" do
+        let(:path) { '.\test.conf' }
+        it 'work with relative windows path' do
+          subject.load_config(path)
+        end
+      end
+    end
+    
+    context "when remote" do
+      context 'supported scheme' do
+        let(:path) { "http://test.local/superconfig.conf" }
+
+        before { expect(Net::HTTP).to receive(:get) { dummy_config } }
+        it 'works with http' do
+          expect(subject.load_config(path)).to eq("#{dummy_config}\n")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Relatives path on windows fails to pass the `URI.parse` method as I fix I suggest we fallback to local configuration.
fixes https://github.com/elasticsearch/logstash/issues/2504