### PR TITLE
ensure all strings pulled out of ENV are UTF8 on windows

### DIFF
--- a/lib/logstash/monkeypatches-for-bugs.rb
+++ b/lib/logstash/monkeypatches-for-bugs.rb
@@ -32,3 +32,19 @@ if LogStash::Environment.windows? && LogStash::Environment.jruby?
     include JRubyBug2558SocketPeerAddrBugFix
   end
 end
+
+if LogStash::Environment.windows?
+  # make sure all strings pulled out of ENV are UTF8
+  class <<ENV
+    alias_method :orig_getter, :[]
+    def [](key)
+      case value = orig_getter(key)
+      when String
+        # dup is necessary since force_encoding is destructive
+        value.dup.force_encoding(Encoding::UTF_8)
+      else
+        value
+      end
+    end
+  end
+end


### PR DESCRIPTION
strings assigned to LogStash::Event fields must be UTF-8 and
since most windows aren't UTF-8 by default we must intercept all
get operations and convert the strings to UTF-8. Issue surfaces in
logstash-filter-environment, for example.

fixes https://github.com/logstash-plugins/logstash-filter-environment/issues/1