### PR TITLE
Make sure we expand the path to make Dir.glob work on windows if we provide a relative file like .\hello

### DIFF
--- a/lib/logstash/agent.rb
+++ b/lib/logstash/agent.rb
@@ -316,6 +316,7 @@ class LogStash::Agent < Clamp::Command
   end
 
   def local_config(path)
+    path = File.expand_path(path)
     path = File.join(path, "*") if File.directory?(path)
 
     if Dir.glob(path).length == 0


### PR DESCRIPTION
```
irb(main):005:0> Dir.glob('.\test.conf')
=> []
irb(main):006:0> Dir.glob(File.expand_path('.\test.conf'))
=> ["C:/Users/Administrator/test.conf"]
```
Fixes https://github.com/elasticsearch/logstash/issues/2504