### PR TITLE
Update README with the right rake task to setup a development environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To get started, you'll need ruby version 1.9.x or above and it should come with 
 
 Here's how to get started with Logstash development:
 
-    rake bootstrap
+    rake test:install-core
 
 Other commands:
 


### PR DESCRIPTION
Using the `rake bootstrap` command doesn't correctly setup a development environment, updating the doc with the new `rake test:install-core`

fixes: https://github.com/elasticsearch/logstash/issues/2688