### PR TITLE
logstash 1.5.0.beta1 version bump to 1.5.0.beta2

### DIFF
--- a/lib/logstash/version.rb
+++ b/lib/logstash/version.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # The version of logstash.
-LOGSTASH_VERSION = "1.5.0.beta1"
+LOGSTASH_VERSION = "1.5.0.beta2"
 
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.


### PR DESCRIPTION
Easy and simple as this.