### PR TITLE
correctly override & init bundler settings

### DIFF
--- a/lib/logstash/bundler.rb
+++ b/lib/logstash/bundler.rb
@@ -18,16 +18,6 @@ module Bundler
         @definition = nil
       end
     end
-
-    def reset_settings
-      # reset!
-      # clear_gemspec_cache
-
-      # remove_instance_variable(:@setup) if defined?(@setup)
-      # remove_instance_variable(:@locked_gems) if defined?(@locked_gems)
-      # remove_instance_variable(:@load) if defined?(@load)
-      remove_instance_variable(:@settings) if defined?(@settings)
-    end
   end
 end
 
@@ -62,9 +52,10 @@ module LogStash
       options[:update] = Array(options[:update]) if options[:update]
 
       ENV["GEM_PATH"] = LogStash::Environment.logstash_gem_home
-      ENV["BUNDLE_PATH"] = LogStash::Environment::BUNDLE_DIR
-      ENV["BUNDLE_GEMFILE"] = LogStash::Environment::GEMFILE_PATH
-      ENV["BUNDLE_WITHOUT"] = options[:without].join(":")
+
+      ::Bundler.settings[:path] = LogStash::Environment::BUNDLE_DIR
+      ::Bundler.settings[:gemfile] = LogStash::Environment::GEMFILE_PATH
+      ::Bundler.settings[:without] = options[:without].join(":")
 
       try = 0
 
@@ -105,13 +96,7 @@ module LogStash
 
       if options[:install]
         arguments << "install"
-        arguments << "--gemfile=#{LogStash::Environment::GEMFILE_PATH}"
-        arguments << ["--path", LogStash::Environment::BUNDLE_DIR]
-        # note that generating "--without=" when options[:without] is empty is intended
-        arguments << "--without=#{options[:without].join(' ')}"
-      end
-
-      if options[:update]
+      elsif options[:update]
         arguments << "update"
         arguments << options[:update]
       end

--- a/lib/logstash/bundler.rb
+++ b/lib/logstash/bundler.rb
@@ -96,12 +96,13 @@ module LogStash
 
       if options[:install]
         arguments << "install"
+        arguments << "--clean" if options[:clean]
       elsif options[:update]
         arguments << "update"
         arguments << options[:update]
+      elsif options[:clean]
+        arguments << "clean"
       end
-
-      arguments << "--clean" if options[:clean]
 
       arguments.flatten
     end

--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -91,23 +91,15 @@ module LogStash
     end
 
     def bundler_setup!
-      # if there's no .bundle/config setup the runtime environment.
-      unless ::File.exists?(BUNDLE_CONFIG_PATH)
-        ENV["BUNDLE_PATH"] = LogStash::Environment::BUNDLE_DIR
-        ENV["BUNDLE_WITHOUT"] = "development"
-      end
-      # force BUNDLE_GEMFILE since Bundler does not store it in its ./bundle/config. this is required otherwise Bundler will look for the Gemfile in the CWD
-      # and will crash when invoking logstash outside its home dir.
-      ENV["BUNDLE_GEMFILE"] = LogStash::Environment::GEMFILE_PATH
-
       # make sure we use our own nicely installed bundler and not a rogue, bad, mean, ugly, stupid other bundler. bad bundler, bad bad bundler go away.
       Gem.clear_paths
       Gem.paths = ENV['GEM_HOME'] = ENV['GEM_PATH'] = logstash_gem_home
       require "bundler"
-
       require "logstash/bundler"
 
-      ::Bundler.reset_settings # our monkey patched method
+      ::Bundler.settings[:path] = LogStash::Environment::BUNDLE_DIR
+      ::Bundler.settings[:gemfile] = LogStash::Environment::GEMFILE_PATH
+      ::Bundler.settings[:without] = "development"
       ::Bundler.reset!
       ::Bundler.setup
     end


### PR DESCRIPTION
always force bundler settings, regardless of `.bundle/config`. previous ENV settings where actually not working. 

with this we can get rid of the `reset_settings` monkey patch, also get rid of the non-existant `.bundle/config` condition and we do not need to pass extra arguments to `Bundler::CLI.start` other than the actual command.

win, win win.