### PR TITLE
add the logstash-core.gemspec to the artifact build

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -9,7 +9,7 @@ namespace "artifact" do
       "patterns/**/*",
       "vendor/??*/**/*",
       "Gemfile*",
-      "logstash.gemspec",
+      "logstash-core.gemspec",
     ]
   end
 


### PR DESCRIPTION
Adds the logstash-core gemspec, so the tar artifact can start loading the env to do work as expected.