### PR TITLE
add logstash-output-logentries to the skiplist when doing install-all until the plugin is actually published

### DIFF
--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -131,7 +131,8 @@ module LogStash
       /^logstash-filter-yaml$/,
       /jms$/,
       /example$/,
-      /drupal/i
+      /drupal/i,
+      /logstash-output-logentries/i
     ])
 
 

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -132,7 +132,8 @@ module LogStash
       /jms$/,
       /example$/,
       /drupal/i,
-      /logstash-output-logentries/i
+      /logstash-output-logentries$/,
+      /logstash-input-jdbc$/
     ])
 
 


### PR DESCRIPTION
fixes: #2715