### PR TITLE
set BUNDLE_GEMFILE before requiring bundler

### DIFF
--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -94,16 +94,19 @@ module LogStash
       # make sure we use our own nicely installed bundler and not a rogue, bad, mean, ugly, stupid other bundler. bad bundler, bad bad bundler go away.
       Gem.clear_paths
       Gem.paths = ENV['GEM_HOME'] = ENV['GEM_PATH'] = logstash_gem_home
+
+      # set BUNDLE_GEMFILE ENV before requiring bundler to avoid bundler recurse and load unrelated Gemfile(s)
+      ENV["BUNDLE_GEMFILE"] = LogStash::Environment::GEMFILE_PATH
+
       require "bundler"
       require "logstash/bundler"
 
       ::Bundler.settings[:path] = LogStash::Environment::BUNDLE_DIR
       ::Bundler.settings[:without] = "development"
 
+      # in the context of Bundler.setup it looks like this is useless here because Gemfile path can only be specified using
+      # the ENV, see https://github.com/bundler/bundler/blob/v1.8.3/lib/bundler/shared_helpers.rb#L103
       ::Bundler.settings[:gemfile] = LogStash::Environment::GEMFILE_PATH
-      # also set ENV because bundler does not check settings for :gemfile here
-      # https://github.com/bundler/bundler/blob/v1.8.3/lib/bundler/shared_helpers.rb#L103
-      ENV["BUNDLE_GEMFILE"] = LogStash::Environment::GEMFILE_PATH
 
       ::Bundler.reset!
       ::Bundler.setup


### PR DESCRIPTION
this fixes bundler trying to recurse into subdirs to find Gemfile and potentially load unrelated Gemfile(s). This is potentially problematic when launching logstash outside its home directory since Bundler will recurse from the launch point. 