### PR TITLE
Call `bundler_setup!` before fetch the gem specifications

### DIFF
--- a/lib/logstash/environment.rb
+++ b/lib/logstash/environment.rb
@@ -92,8 +92,8 @@ module LogStash
 
     def bundler_setup!
       # make sure we use our own nicely installed bundler and not a rogue, bad, mean, ugly, stupid other bundler. bad bundler, bad bad bundler go away.
-      Gem.clear_paths
-      Gem.paths = ENV['GEM_HOME'] = ENV['GEM_PATH'] = logstash_gem_home
+      ::Gem.clear_paths
+      ::Gem.paths = ENV['GEM_HOME'] = ENV['GEM_PATH'] = logstash_gem_home
 
       # set BUNDLE_GEMFILE ENV before requiring bundler to avoid bundler recurse and load unrelated Gemfile(s)
       ENV["BUNDLE_GEMFILE"] = LogStash::Environment::GEMFILE_PATH

--- a/lib/logstash/pluginmanager/list.rb
+++ b/lib/logstash/pluginmanager/list.rb
@@ -15,6 +15,9 @@ class LogStash::PluginManager::List < Clamp::Command
   end
 
   def execute
+    require 'logstash/environment'
+    LogStash::Environment.bundler_setup!
+
     Gem.configuration.verbose = false
 
     gemfile = LogStash::Gemfile.new(File.new(LogStash::Environment::GEMFILE_PATH, "r+")).load


### PR DESCRIPTION
Gems declared in the `gemfile` with the :path or the :git option should be displayed when calling `bin/plugin list`, the current behavior only list the gems if they are available in the current `GEM_PATH`
Fixes https://github.com/elasticsearch/logstash/issues/2692