### PR TITLE
Use warn level instead of error level when a plugin is using the milestone method in the plugin

### DIFF
--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -137,7 +137,7 @@ module LogStash::Config::Mixin
     # inside the gemspec.
     def milestone(m = nil)
       @logger = Cabin::Channel.get(LogStash)
-      @logger.error(I18n.t('logstash.plugin.deprecated_milestone', :plugin => config_name))
+      @logger.warn(I18n.t('logstash.plugin.deprecated_milestone', :plugin => config_name))
     end
 
     # Define a new configuration setting

--- a/spec/core/plugin_spec.rb
+++ b/spec/core/plugin_spec.rb
@@ -93,8 +93,8 @@ describe LogStash::Plugin do
     end
     
 
-    it 'logs an error if the plugin use the milestone option' do
-      expect_any_instance_of(Cabin::Channel).to receive(:error)
+    it 'logs a warning if the plugin use the milestone option' do
+      expect_any_instance_of(Cabin::Channel).to receive(:warn)
         .with(/stromae plugin is using the 'milestone' method/)
 
       class LogStash::Filters::Stromae < LogStash::Filters::Base


### PR DESCRIPTION
uses `warn` instead of `error` when a plugin is using defining a version with the milestone method.