### PR TITLE
raise helpful error when formatting time without @timestamp field

### DIFF
--- a/lib/logstash/event.rb
+++ b/lib/logstash/event.rb
@@ -224,6 +224,10 @@ class LogStash::Event
       # Take the inside of the %{ ... }
       key = tok[2 ... -1]
 
+      if key[0] == "+" && !@data.has_key?(TIMESTAMP)
+        raise LogStash::Error, "Unable to format \"#{key}\" in string \"#{format}\", #{TIMESTAMP} field not found"
+      end
+
       if key == "+%s"
         # Got %{+%s}, support for unix epoch time
         next @data[TIMESTAMP].to_i

--- a/spec/core/event_spec.rb
+++ b/spec/core/event_spec.rb
@@ -67,10 +67,24 @@ describe LogStash::Event do
       expect(subject.sprintf("%{+%s}")).to eq("1356998400")
     end
 
+    it "should raise error when formatting %{+%s} when @timestamp field is missing" do
+      str = "hello-%{+%s}"
+      subj = subject.clone
+      subj.remove("[@timestamp]")
+      expect{ subj.sprintf(str) }.to raise_error(LogStash::Error)
+    end
+
     it "should report a time with %{+format} syntax", :if => RUBY_ENGINE == "jruby" do
       expect(subject.sprintf("%{+YYYY}")).to eq("2013")
       expect(subject.sprintf("%{+MM}")).to eq("01")
       expect(subject.sprintf("%{+HH}")).to eq("00")
+    end
+
+    it "should raise error with %{+format} syntax when @timestamp field is missing", :if => RUBY_ENGINE == "jruby" do
+      str = "logstash-%{+YYYY}"
+      subj = subject.clone
+      subj.remove("[@timestamp]")
+      expect{ subj.sprintf(str) }.to raise_error(LogStash::Error)
     end
 
     it "should report fields with %{field} syntax" do


### PR DESCRIPTION
in response to: https://github.com/elasticsearch/logstash/issues/2730

When calling `sprintf` with time related formatting, an error is thrown because `sprintf` is trying to use the 
timestamp field without checking whether it exists or not.

This affects 
`Event#sprintf("%{+%s}")` and `Event#sprintf("%{+format}")` calls.

After this fix:
```ruby
event = LogStash::Event.new("@timestamp" => Time.iso8601("2013-01-01T00:00:00.000Z"))
event.sprintf("%{+%s}")  # 1356998400
event.sprintf("%{+YYYY}")  # 2013
event.remove("[@timestamp]")
event.sprintf("%{+%s}")  # raise LogStash::Error
event.sprintf("%{+YYYY}")  # raise LogStash::Error
```