### PR TITLE
list updated plugins upon completion of bin/plugin update

### DIFF
--- a/lib/logstash/pluginmanager/update.rb
+++ b/lib/logstash/pluginmanager/update.rb
@@ -16,18 +16,20 @@ class LogStash::PluginManager::Update < Clamp::Command
     # keep a copy of the gemset to revert on error
     original_gemset = gemfile.gemset.copy
 
+    previous_gem_specs_map = find_latest_gem_specs
+
     # create list of plugins to update
     plugins = unless plugin_list.empty?
-      not_installed = plugin_list.find{|plugin| !LogStash::PluginManager.installed_plugin?(plugin, gemfile)}
-      raise(LogStash::PluginManager::Error, "Plugin #{not_installed} has not been previously installed, aborting") if not_installed
+      not_installed = plugin_list.select{|plugin| !previous_gem_specs_map.has_key?(plugin.downcase)}
+      raise(LogStash::PluginManager::Error, "Plugin #{not_installed.join(', ')} has not been previously installed, aborting") unless not_installed.empty?
       plugin_list
     else
-      LogStash::PluginManager.all_installed_plugins_gem_specs(gemfile).map{|spec| spec.name}
+      previous_gem_specs_map.values.map{|spec| spec.name}
     end
 
     # remove any version constrain from the Gemfile so the plugin(s) can be updated to latest version
     # calling update without requiremend will remove any previous requirements
-    plugins.each{|plugin| gemfile.update(plugin)}
+    plugins.select{|plugin| gemfile.find(plugin)}.each{|plugin| gemfile.update(plugin)}
     gemfile.save
 
     puts("Updating " + plugins.join(", "))
@@ -42,6 +44,33 @@ class LogStash::PluginManager::Update < Clamp::Command
       gemfile.save
 
       report_exception(output, exception)
+    end
+
+    update_count = 0
+    find_latest_gem_specs.values.each do |spec|
+      name = spec.name.downcase
+      if previous_gem_specs_map.has_key?(name)
+        if spec.version != previous_gem_specs_map[name].version
+          puts("Updated #{spec.name} #{previous_gem_specs_map[name].version.to_s} to #{spec.version.to_s}")
+          update_count += 1
+        end
+      else
+        puts("Installed #{spec.name} #{spec.version.to_s}")
+        update_count += 1
+      end
+    end
+    puts("No plugin updated") if update_count.zero?
+  end
+
+  private
+
+  # retrieve only the latest spec for all locally installed plugins
+  # @return [Hash] result hash {plugin_name.downcase => plugin_spec}
+  def find_latest_gem_specs
+    LogStash::PluginManager.find_plugins_gem_specs.inject({}) do |result, spec|
+      previous = result[spec.name.downcase]
+      result[spec.name.downcase] = previous ? [previous, spec].max_by{|s| s.version} : spec
+      result
     end
   end
 

--- a/lib/logstash/pluginmanager/update.rb
+++ b/lib/logstash/pluginmanager/update.rb
@@ -21,7 +21,7 @@ class LogStash::PluginManager::Update < Clamp::Command
     # create list of plugins to update
     plugins = unless plugin_list.empty?
       not_installed = plugin_list.select{|plugin| !previous_gem_specs_map.has_key?(plugin.downcase)}
-      raise(LogStash::PluginManager::Error, "Plugin #{not_installed.join(', ')} has not been previously installed, aborting") unless not_installed.empty?
+      raise(LogStash::PluginManager::Error, "Plugin #{not_installed.join(', ')} is not installed so it cannot be updated, aborting") unless not_installed.empty?
       plugin_list
     else
       previous_gem_specs_map.values.map{|spec| spec.name}

--- a/lib/logstash/pluginmanager/util.rb
+++ b/lib/logstash/pluginmanager/util.rb
@@ -63,7 +63,7 @@ module LogStash::PluginManager
   # note that an installed plugin dependecies like codecs will not be listed, only those
   # specifically listed in the Gemfile.
   # @param gemfile [LogStash::Gemfile] the gemfile to validate against
-  # @return [Array<Gem::Specification>] list of plugin names
+  # @return [Array<Gem::Specification>] list of plugin specs
   def self.all_installed_plugins_gem_specs(gemfile)
     # we start form the installed gemspecs so we can verify the metadata for valid logstash plugin
     # then filter out those not included in the Gemfile


### PR DESCRIPTION
fixes #2625 
with this the new behaviour is:
- any local plugin gem can be updated, not just the one in the Gemfile, so any plugin showing in `bin/plugin list` can be updated.
- all updated plugins will display:
```
Updated logstash-input-awesome 0.0.1 to 1.2.3
```
- if the update process triggers the installation of a new plugin, it will show:
```
Installed logstash-codec-awesome 1.2.3
```
- otherwise if nothing gets installed or updated it will show:
```
No plugin updated
```