### PR TITLE
do not wrap existing Password type into another Password type when validating

### DIFF
--- a/lib/logstash/config/mixin.rb
+++ b/lib/logstash/config/mixin.rb
@@ -451,7 +451,7 @@ module LogStash::Config::Mixin
               return false, "Expected password (one value), got #{value.size} values?"
             end
 
-            result = ::LogStash::Util::Password.new(value.first)
+            result = value.first.is_a?(::LogStash::Util::Password) ? value.first : ::LogStash::Util::Password.new(value.first)
           when :path
             if value.size > 1 # Only 1 value wanted
               return false, "Expected path (one value), got #{value.size} values?"

--- a/spec/core/config_mixin_spec.rb
+++ b/spec/core/config_mixin_spec.rb
@@ -66,4 +66,34 @@ describe LogStash::Config::Mixin do
       }.to raise_error(LogStash::ConfigurationError)
     end
   end
+
+  context "when validating :password" do
+    let(:klass) do
+      Class.new(LogStash::Filters::Base)  do
+        config_name "fake"
+        config :password, :validate => :password
+      end
+    end
+
+    let(:secret) { "fancy pants" }
+    subject { klass.new("password" => secret) }
+
+    it "should be a Password object" do
+      expect(subject.password).to(be_a(LogStash::Util::Password))
+    end
+
+    it "should make password values hidden" do
+      expect(subject.password.to_s).to(be == "<password>")
+      expect(subject.password.inspect).to(be == "<password>")
+    end
+
+    it "should show password values via #value" do
+      expect(subject.password.value).to(be == secret)
+    end
+
+    it "should correctly copy password types" do
+      clone = subject.class.new(subject.params)
+      expect(clone.password.value).to(be == secret)
+    end
+  end
 end


### PR DESCRIPTION
brought to you buy @jordansissel and @untergeek.

There was an issue wherein cloning plugins with `:password` config types would cause problems. The 
config fields being cloned were being validated again, and `:password` validation would wrap the existing 
valid `Password` types into new `Password` objects. Here is the fix for that.

context: https://github.com/elasticsearch/logstash/issues/2764 and https://github.com/logstash-plugins/logstash-output-redis/issues/6